### PR TITLE
Stabilize CI

### DIFF
--- a/test/ered_SUITE.erl
+++ b/test/ered_SUITE.erl
@@ -37,12 +37,12 @@ init_per_suite(Config) ->
     InitialNodes = [{localhost, Port} || Port <- ?PORTS],
     {ok, R} = ered:start_link(InitialNodes, [{info_pid, [self()]}]),
 
-    cmd_log("docker run --name redis-1 -d --net=host --restart=on-failure redis redis-server --cluster-enabled yes --port 30001 --cluster-node-timeout 2000;"
-            "docker run --name redis-2 -d --net=host --restart=on-failure redis redis-server --cluster-enabled yes --port 30002 --cluster-node-timeout 2000;"
-            "docker run --name redis-3 -d --net=host --restart=on-failure redis redis-server --cluster-enabled yes --port 30003 --cluster-node-timeout 2000;"
-            "docker run --name redis-4 -d --net=host --restart=on-failure redis redis-server --cluster-enabled yes --port 30004 --cluster-node-timeout 2000;"
-            "docker run --name redis-5 -d --net=host --restart=on-failure redis redis-server --cluster-enabled yes --port 30005 --cluster-node-timeout 2000;"
-            "docker run --name redis-6 -d --net=host --restart=on-failure redis redis-server --cluster-enabled yes --port 30006 --cluster-node-timeout 2000;"),
+    cmd_log("docker run --name redis-1 -d --net=host --restart=on-failure redis:6.2.7 redis-server --cluster-enabled yes --port 30001 --cluster-node-timeout 2000;"
+            "docker run --name redis-2 -d --net=host --restart=on-failure redis:6.2.7 redis-server --cluster-enabled yes --port 30002 --cluster-node-timeout 2000;"
+            "docker run --name redis-3 -d --net=host --restart=on-failure redis:6.2.7 redis-server --cluster-enabled yes --port 30003 --cluster-node-timeout 2000;"
+            "docker run --name redis-4 -d --net=host --restart=on-failure redis:6.2.7 redis-server --cluster-enabled yes --port 30004 --cluster-node-timeout 2000;"
+            "docker run --name redis-5 -d --net=host --restart=on-failure redis:6.2.7 redis-server --cluster-enabled yes --port 30005 --cluster-node-timeout 2000;"
+            "docker run --name redis-6 -d --net=host --restart=on-failure redis:6.2.7 redis-server --cluster-enabled yes --port 30006 --cluster-node-timeout 2000;"),
 
     timer:sleep(1000),
     lists:foreach(fun(Port) ->
@@ -50,7 +50,7 @@ init_per_suite(Config) ->
                           {ok, <<"PONG">>} = ered_client:command(Pid, <<"ping">>)
                   end, ?PORTS),
 
-    cmd_log(" echo 'yes' | docker run --name redis-cluster --net=host -i redis redis-cli --cluster create 127.0.0.1:30001 127.0.0.1:30002 127.0.0.1:30003 127.0.0.1:30004 127.0.0.1:30005 127.0.0.1:30006 --cluster-replicas 1"),
+    cmd_log(" echo 'yes' | docker run --name redis-cluster --net=host -i redis:6.2.7 redis-cli --cluster create 127.0.0.1:30001 127.0.0.1:30002 127.0.0.1:30003 127.0.0.1:30004 127.0.0.1:30005 127.0.0.1:30006 --cluster-replicas 1"),
 
     {ok, Tref} = timer:exit_after(20000, cluster_start_timeout),
     fun Loop() ->
@@ -343,7 +343,7 @@ t_new_cluster_master(_) ->
                        {close_wait, 100}]),
 
     %% Create new master
-    cmd_log("docker run --name redis-7 -d --net=host --restart=on-failure redis redis-server --cluster-enabled yes --port 30007 --cluster-node-timeout 2000"),
+    cmd_log("docker run --name redis-7 -d --net=host --restart=on-failure redis:6.2.7 redis-server --cluster-enabled yes --port 30007 --cluster-node-timeout 2000"),
     cmd_until("redis-cli -p 30007 CLUSTER MEET 127.0.0.1 30001", "OK"),
     cmd_until("redis-cli -p 30007 CLUSTER INFO", "cluster_state:ok"),
 


### PR DESCRIPTION
* Stabilize test suite setup    
Wait until all cluster nodes have the same view of the slots mapping.

* Pin Redis version in tests to 6.2.7

* Update testcase `t_new_cluster_master` for Redis 6.2
Manually forget the added node in the end of the testcase.
From Redis version 6.2 a node without slots becomes a replica to a selected master,
but in pre-6.2 the node was removed from the slot map triggering ered to disconnect its client to that node.