### PR TITLE
WIP: CI test stabilization

### DIFF
--- a/test/ered_SUITE.erl
+++ b/test/ered_SUITE.erl
@@ -352,6 +352,7 @@ t_new_cluster_master(_) ->
 
     %% Create new master
     Pod = cmd_log("docker run --name redis-7 -d --net=host --restart=on-failure redis:6.2.7 redis-server --cluster-enabled yes --port 30007 --cluster-node-timeout 2000"),
+    cmd_until("docker container inspect -f '{{.State.Status}}' " ++ Pod, "running"),
     cmd_until("redis-cli -p 30007 CLUSTER MEET 127.0.0.1 30001", "OK"),
     cmd_until("redis-cli -p 30007 CLUSTER INFO", "cluster_state:ok"),
 

--- a/test/ered_SUITE.erl
+++ b/test/ered_SUITE.erl
@@ -612,14 +612,17 @@ cmd_log(Cmd) ->
     R.
 
 cmd_until(Cmd, Regex) ->
+    io:format(user, "cmd_until: Cmd: ~p Regex: ~p~n", [Cmd, Regex]),
     fun Loop(N) ->
             case re:run(cmd_log(Cmd), Regex) of
                 nomatch when N > 0 ->
+                    io:format(user, "cmd_until: no match~n", []),
                     timer:sleep(500),
                     Loop(N -1);
                 nomatch when N =< 0 ->
                     error({timeout_cmd_until, Cmd, Regex});
                 Match ->
+                    io:format(user, "cmd_until: match!~n", []),
                     Match
             end
     end(20).


### PR DESCRIPTION
Test of solution:
Add a wait for the temporary test container to be in state `running`.
