### PR TITLE
Use sets:set() for RESP3 sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,32 @@ ered
 An Erlang client library for connecting to Redis Cluster
 aiming to replace [eredis](https://github.com/Nordix/eredis) and [eredis_cluster](https://github.com/Nordix/eredis_cluster).
 
-Status: WIP. See issues.
+Status: Beta.
 
 Features:
 
 * status events
 * queuing and load shedding (to handle burst traffic)
 * pipelining of commands
-* RESP3 support
+* [RESP3](https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md) support
 * ASK redirection supporting hash tags
+
+Redis to Erlang Term Representation
+-----------------------------------
+
+| Redis (RESP3)         | Erlang                                             |
+|-----------------------|----------------------------------------------------|
+| Simple string         | `binary()`                                         |
+| Bulk string           | `binary()`                                         |
+| Verbatim string       | `binary()`                                         |
+| Array (multi-bulk)    | `list()`                                           |
+| Map                   | `map()`                                            |
+| Set                   | `sets:set()` (version 2 in OTP 24+)                |
+| Null                  | `undefined`                                        |
+| Boolean               | `boolean()`                                        |
+| Integer               | `integer()`                                        |
+| Big number            | `integer()`                                        |
+| Float                 | `float()`, `inf`, `neg_inf`, `nan`                 |
+| Error                 | `{error, binary()}`                                |
+| Value with attributes | `{attribute, Value :: any(), Attributes :: map()}` |
+| Push (out-of-band)    | `{push, list()}`                                   |

--- a/src/ered_parser.erl
+++ b/src/ered_parser.erl
@@ -23,7 +23,7 @@
 
 -type parse_function() :: fun((binary()) -> {done, parse_result()} | {cont, parse_function(), bytes_needed()}).
 
--type parse_result() :: binary() | {error, binary()} | integer() | undefined | [parse_result()] | inf | neg_inf |
+-type parse_result() :: binary() | {error, binary()} | integer() | undefined | [parse_result()] | inf | neg_inf | nan |
                         float() | true | false | #{parse_result() => parse_result()} | sets:set(parse_result()) |
                         {attribute, parse_result(), parse_result()} | {push | parse_result()}.
 
@@ -109,6 +109,8 @@ parse_initial(Token) ->
         <<"_" >>             -> {done, undefined}; % Null
         <<",inf">>           -> {done, inf}; % float inifinity
         <<",-inf">>          -> {done, neg_inf}; % negative infinity
+        <<",nan">>           -> {done, nan}; % NaN
+        <<",-nan">>          -> {done, nan}; % returned by some versions of redis
         <<",", Rest/binary>> -> {done, parse_float(Rest)};
         <<"#t">>             -> {done, true};
         <<"#f">>             -> {done, false};

--- a/test/ered_parser_tests.erl
+++ b/test/ered_parser_tests.erl
@@ -33,6 +33,8 @@ test_data() ->
      {"float no decimal",  <<",10\r\n">>,                                              10.0},
      {"float inf",         <<",inf\r\n">>,                                             inf},
      {"float neg inf",     <<",-inf\r\n">>,                                            neg_inf},
+     {"float nan",         <<",nan\r\n">>,                                             nan},
+     {"float neg nan",     <<",-nan\r\n">>,                                            nan},
      {"boolean true",      <<"#t\r\n">>,                                               true},
      {"boolean false",     <<"#f\r\n">>,                                               false},
      {"blob error",        <<"!21\r\nSYNTAX invalid syntax\r\n">>,                     {error, <<"SYNTAX invalid syntax">>}},

--- a/test/ered_parser_tests.erl
+++ b/test/ered_parser_tests.erl
@@ -2,6 +2,12 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+-if(?OTP_RELEASE >= 24).
+set_from_list(List) -> sets:from_list(List, [{version, 2}]).
+-else.
+set_from_list(List) -> sets:from_list(List).
+-endif.
+
 test_data() ->
     [
      %% Test data taken from the Redis Protocol (RESP) specification
@@ -33,8 +39,7 @@ test_data() ->
      {"verbatim string",   <<"=15\r\ntxt:Some string\r\n">>,                           <<"txt:Some string">>},
      {"big number",        <<"(3492890328409238509324850943850943825024385\r\n">>,     3492890328409238509324850943850943825024385},
      {"map",               <<"%2\r\n+first\r\n:1\r\n+second\r\n:2\r\n">>,              #{<<"first">> => 1, <<"second">> => 2}},
-     {"set",               <<"~5\r\n+orange\r\n+apple\r\n#t\r\n:100\r\n:999\r\n">>,    #{<<"orange">> => true, <<"apple">> => true,
-                                                                                         true => true, 100 => true, 999 => true}},
+     {"set",               <<"~5\r\n+orange\r\n+apple\r\n#t\r\n:100\r\n:999\r\n">>,    set_from_list([<<"orange">>, <<"apple">>, true, 100, 999])},
      {"attribute",         <<"|1\r\n+key-popularity\r\n%2\r\n$1\r\na\r\n,0.1923\r\n"
                              "$1\r\nb\r\n,0.0012\r\n*2\r\n:2039123\r\n:9543892\r\n">>,  {attribute, [2039123, 9543892],
                                                                                          #{<<"key-popularity">> =>
@@ -49,8 +54,7 @@ test_data() ->
      {"streamed array",   <<"*?\r\n:1\r\n:2\r\n:3\r\n.\r\n">>,                          [1, 2, 3]},
      {"streamed map",     <<"%?\r\n+a\r\n:1\r\n+b\r\n:2\r\n.\r\n">>,                    #{<<"a">> => 1, <<"b">> => 2}},
      %% Additional tests
-     {"streamed set",     <<"~?\r\n+a\r\n:1\r\n+b\r\n:2\r\n.\r\n">>,                    #{<<"a">> => true, 1 => true,
-                                                                                          <<"b">> => true, 2 => true}},
+     {"streamed set",     <<"~?\r\n+a\r\n:1\r\n+b\r\n:2\r\n.\r\n">>,                    set_from_list([<<"a">>, 1, <<"b">>, 2])},
      {"float negative", <<",-1.23\r\n">>, -1.23}
     ].
 


### PR DESCRIPTION
Sets version 2 is used on OTP 24+ (which means it's implemented as a map). On OTP < 24, the old sets:set() represenation is used.

Additionally changes: Handle NaN values returned by Redis, returned as the atom 'nan'.

Document the Erlang representation of Redis datatypes in the README.