### PR TITLE
No online deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
           sudo apt install emacs-nox
       - name: erlang-formatter
         run: |
-          rebar3 fmt
+          rebar3 as check fmt
           status="$(git status --untracked-file=no --porcelain)"
           if [ ! -z "$status" ]; \
           then \
-             echo "Error: Please format the following files (e.g. run 'rebar3 fmt')"; \
+             echo "Error: Please format the following files (e.g. run 'rebar3 as check fmt')"; \
              echo "$status"; \
              exit 1; \
           fi

--- a/rebar.config
+++ b/rebar.config
@@ -2,17 +2,10 @@
 
 {eunit_opts, [verbose]}.
 
-{edoc_opts, [{doclet, edown_doclet},
-             {report_missing_types, true},
-             {preprocess, true},
-             {app_default, "https://www.erlang.org/doc/man"}
-            ]}.
+%% There are no dependencies by default.
+%%
+%% However, the profile 'check' includes online dependencies. Run 'rebar3 as
+%% check fmt' to check code formatting. This is used by the CI jobs to check
+%% code formatting.
 
-{profiles, [{docs, [{deps,
-                     [{edown,
-                       {git, "https://github.com/uwiger/edown.git",
-                        {branch, "master"}}}
-                     ]}]
-            }]}.
-
-{plugins, [{rebar3_fmt, "1.18.0"}]}.
+{profiles, [{check, [{plugins, [{rebar3_fmt, "1.18.0"}]}]}]}.


### PR DESCRIPTION
Drop edown and edoc since there are no edoc comments in the code anyway.

Remove rebar3_fmt from global plugins and use it only in the 'check' rebar3 profile. This means we have no online deps by default, but it can be enabled again by explicitly running 'rebar3 as check fmt'. This is used by CI.