### PR TITLE
Avoid sending CLUSTER SLOTS to unavailable nodes

### DIFF
--- a/src/ered_cluster.erl
+++ b/src/ered_cluster.erl
@@ -44,6 +44,9 @@
              queue_full = new_set([]) :: addr_set(),
              %% Clients started but not connected yet
              pending = new_set([]) :: addr_set(),
+             %% Clients that lost connection and trying to reconnect, probably a
+             %% harmless situation. These are still considered 'up'.
+             reconnecting = new_set([]) :: addr_set(),
              %% Clients pending to be closed. Mapped to the closing timer
              %% reference
              closing = #{} :: #{addr() => reference()},
@@ -191,15 +194,18 @@ handle_info(Msg = {connection_status, {_Pid, Addr, _Id} , Status}, State) ->
     ered_info_msg:connection_status(Msg, IsMaster, State#st.info_pid),
     State1 = case Status of
                  {connection_down, {socket_closed, _}} ->
-                     %% Avoid triggering the alarm for a normal from peer side.
-                     %% The cluster will be marked down on connect or node down event.
-                     State;
+                     %% Avoid triggering the alarm for a socket closed by the
+                     %% peer. The cluster will be marked down on failed
+                     %% reconnect or node down event.
+                     State#st{reconnecting = sets:add_element(Addr, State#st.reconnecting)};
                  {connection_down,_} ->
                      State#st{up = sets:del_element(Addr, State#st.up),
-                              pending = sets:del_element(Addr, State#st.pending)};
+                              pending = sets:del_element(Addr, State#st.pending),
+                              reconnecting = sets:del_element(Addr, State#st.reconnecting)};
                  connection_up ->
                      State#st{up = sets:add_element(Addr, State#st.up),
-                              pending = sets:del_element(Addr, State#st.pending)};
+                              pending = sets:del_element(Addr, State#st.pending),
+                              reconnecting = sets:del_element(Addr, State#st.reconnecting)};
                  queue_full ->
                      State#st{queue_full = sets:add_element(Addr, State#st.queue_full)};
                  queue_ok ->
@@ -386,22 +392,44 @@ send_slot_info_request(Node, State) ->
     Cb = fun(Answer) -> Pid ! {slot_info, State#st.slot_map_version, Answer} end,
     ered_client:command_async(Node, [<<"CLUSTER">>, <<"SLOTS">>], Cb).
 
+%% Pick a random available node, preferring the ones in PreferredNodes if any of
+%% them is available.
+%%
+%% Random is useful, since we may send multiple async CLUSTER SLOTS before we
+%% get a reply for the first one, so we don't want the same node over and over.
 pick_node(PreferredNodes, State) ->
-    case sets:is_empty(State#st.up) of
-        true ->
+    case pick_available_node(shuffle(PreferredNodes), State) of
+        none ->
+            %% No preferred node available. Pick one from the 'up' set.
+            Addr = pick_available_node(shuffle(sets:to_list(State#st.up)), State);
+        Addr ->
+            Addr
+    end,
+    case Addr of
+        none ->
             none;
-        false ->
-            %% prioritize initial configured nodes
-            case lists:dropwhile(fun(Addr) -> not sets:is_element(Addr, State#st.up) end,
-                                 PreferredNodes) of
-                [] ->
-                    %% no initial node up, pick one from the up set
-                    Addr = hd(sets:to_list(State#st.up));
-                [Addr|_] ->
-                    Addr
-            end,
+        _ ->
             maps:get(Addr, State#st.nodes)
     end.
+
+shuffle(List) ->
+    [Y || {_, Y} <- lists:sort([{rand:uniform(16384), X} || X <- List])].
+
+%% Pick node that is up and not queue full.
+pick_available_node([Addr|Addrs], State) ->
+    case node_is_available(Addr, State) of
+        true ->
+            Addr;
+        false ->
+            pick_available_node(Addrs, State)
+    end;
+pick_available_node([], _State) ->
+    none.
+
+node_is_available(Addr, State) ->
+    sets:is_element(Addr, State#st.up) andalso
+        not sets:is_element(Addr, State#st.queue_full) andalso
+        not sets:is_element(Addr, State#st.reconnecting).
 
 is_slot_map_ok(State) ->
     %% Need at least two nodes in the cluster. During some startup scenarios it

--- a/src/ered_cluster.erl
+++ b/src/ered_cluster.erl
@@ -439,10 +439,10 @@ node_is_available(Addr, State) ->
 -spec replicas_of_unavailable_masters(#st{}) -> [addr()].
 replicas_of_unavailable_masters(State) ->
     DownMasters = sets:subtract(State#st.masters, State#st.up),
-    case sets:size(DownMasters) of
-        0 ->
+    case sets:is_empty(DownMasters) of
+        true ->
             [];
-        _ ->
+        false ->
             ered_lib:slotmap_replicas_of(DownMasters, State#st.slot_map)
     end.
 

--- a/src/ered_lib.erl
+++ b/src/ered_lib.erl
@@ -4,6 +4,7 @@
          slotmap_master_slots/1,
          slotmap_master_nodes/1,
          slotmap_all_nodes/1,
+         slotmap_replicas_of/2,
          hash/1]).
 
 -export_type([slot_map/0,
@@ -68,6 +69,17 @@ slotmap_master_nodes(ClusterSlotsReply) ->
 slotmap_all_nodes(ClusterSlotsReply) ->
     AllNodes = [lists:map(fun node_info/1, Nodes) || [_SlotStart, _SlotEnd | Nodes] <- ClusterSlotsReply],
     lists:sort(lists:append(AllNodes)).
+
+%% - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+-spec slotmap_replicas_of(sets:set(addr()), slot_map()) -> [addr()].
+%%
+%% Get node addresses of all replicas of the given masters
+%% - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+slotmap_replicas_of(Masters, ClusterSlotsReply) ->
+    AllReplicas = [lists:map(fun node_info/1, Replicas)
+                   || [_Start, _End, Master | Replicas] <- ClusterSlotsReply,
+                      sets:is_element(node_info(Master), Masters)],
+    lists:usort(lists:append(AllReplicas)).
 
 node_info([Ip, Port |_])  ->
     if

--- a/test/ered_SUITE.erl
+++ b/test/ered_SUITE.erl
@@ -248,19 +248,14 @@ t_blackhole(_) ->
          NodeDownTimeout + 1000),
     ?MSG(#{msg_type := node_down_timeout, master := true}),
     ?MSG(#{msg_type := cluster_not_ok, reason := master_down}),
-    ?MSG(#{msg_type := socket_closed, reason := {recv_exit, timeout}, master := false},
-         ResponseTimeout + 1000),
-    ?MSG(#{msg_type := node_down_timeout, master := false},
-         NodeDownTimeout + 1000),
-    ?MSG(#{msg_type := slot_map_updated}),
+    ?MSG(#{msg_type := slot_map_updated},
+         5000),
     ?MSG(#{msg_type := cluster_ok}),
     ?MSG(#{msg_type := client_stopped, reason := normal, master := false},
          CloseWait + 1000),
 
     ct:pal("Unpausing container: " ++ os:cmd("docker unpause " ++ Pod)),
 
-    %% The node joins the cluster again as a replica and is discovered by ered.
-    ?MSG(#{msg_type := connected, master := false}),
     no_more_msgs().
 
 


### PR DESCRIPTION
Adds a set of 'reconnecting' nodes, which are not yet considered 'down', just temporarily lost connection.

Don't send CLUSTER SLOTS to any node which is reconnecting or has a full command queue.

Also send CLUSTER SLOTS to a random node, since we may send multiple async CLUSTER SLOTS before we get a reply for the first one, so we don't want the same node over and over.