### PR TITLE
Don't get killed by linked process

### DIFF
--- a/src/ered_client.erl
+++ b/src/ered_client.erl
@@ -234,6 +234,8 @@ handle_info({timeout, _TimerRef, _Msg}, State) ->
     {noreply, State}.
 
 terminate(Reason, State) ->
+    %% Don't get killed by exit signal back from connect loop when we kill it.
+    process_flag(trap_exit, true),
     exit(State#st.connect_loop_pid, kill),
     reply_all({error, {client_stopped, Reason}}, State),
     report_connection_status({connection_down, {client_stopped, Reason}}, State),

--- a/src/ered_lib.erl
+++ b/src/ered_lib.erl
@@ -58,7 +58,7 @@ slotmap_master_slots(ClusterSlotsReply) ->
 %% - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 slotmap_master_nodes(ClusterSlotsReply) ->
     Nodes = [node_info(Master) || [_SlotStart, _SlotEnd, Master | _] <- ClusterSlotsReply],
-    lists:sort(Nodes).
+    lists:usort(Nodes).
 
 %% - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -spec slotmap_all_nodes(slot_map()) -> [addr()].
@@ -67,7 +67,7 @@ slotmap_master_nodes(ClusterSlotsReply) ->
 %% - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 slotmap_all_nodes(ClusterSlotsReply) ->
     AllNodes = [lists:map(fun node_info/1, Nodes) || [_SlotStart, _SlotEnd | Nodes] <- ClusterSlotsReply],
-    lists:sort(lists:append(AllNodes)).
+    lists:usort(lists:append(AllNodes)).
 
 node_info([Ip, Port |_])  ->
     if


### PR DESCRIPTION
and some other minor changes, e.g. use lists:usort when sorting lists of nodes that shouldn't have duplicates.