### PR TITLE
Pub/sub implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,12 +387,16 @@ Pub/sub
 -------
 
 Ered supports pup/sub, including sharded pub/sub, when RESP3 is used. Pushed
-messages are delivered the push callback, so the connection option `push_cb`
+messages are delivered to the push callback, so the connection option `push_cb`
 needs to be provided. See [Connection options](#connection-options).
 
-**Important:** The commands SUBSCRIBE, UNSUBSCRIBE, PSUBSCRIBE, PUNSUBSCRIBE,
-SSUBSCRIBE and SUNSUBSCRIBE must be given in *lowercase* (e.g. "subscribe"),
-otherwise ered gets confused and out of sync. On success these commands return
-`undefined` and one message for each channel is delivered to the push callback
-as a confirmation that subscribing or unsubscribing to the specified channels
-has succeeded.
+For the commands SUBSCRIBE, UNSUBSCRIBE, PSUBSCRIBE, PUNSUBSCRIBE, SSUBSCRIBE
+and SUNSUBSCRIBE, `ered:command/3,4` returns `{ok, undefined}` on success and
+one message for each channel, pattern or shard channel is delivered to the push
+callback as a confirmation that subscribing or unsubscribing succeeded.
+
+Subscriptions are tied to a connection. If the connection is lost, ered
+reconnects automatically, but ered does not automatically subscribe to the same
+channels again after a reconnect. If you want to subscribe again after
+reconnect, [info messages](#info-messages) can be used to detect when a
+connection goes down or comes up.

--- a/README.md
+++ b/README.md
@@ -382,3 +382,17 @@ Redis to Erlang Term Representation
 | Error                 | `{error, binary()}`                                |
 | Value with attributes | `{attribute, Value :: any(), Attributes :: map()}` |
 | Push (out-of-band)    | `{push, list()}`                                   |
+
+Pub/sub
+-------
+
+Ered supports pup/sub, including sharded pub/sub, when RESP3 is used. Pushed
+messages are delivered the push callback, so the connection option `push_cb`
+needs to be provided. See [Connection options](#connection-options).
+
+**Important:** The commands SUBSCRIBE, UNSUBSCRIBE, PSUBSCRIBE, PUNSUBSCRIBE,
+SSUBSCRIBE and SUNSUBSCRIBE must be given in *lowercase* (e.g. "subscribe"),
+otherwise ered gets confused and out of sync. On success these commands return
+`undefined` and one message for each channel is delivered to the push callback
+as a confirmation that subscribing or unsubscribing to the specified channels
+has succeeded.

--- a/src/ered_connection.erl
+++ b/src/ered_connection.erl
@@ -229,7 +229,6 @@ handle_result({push, Value = [Type|_]}, ParserState, State) ->
     PushCB(Value),
     State1 = case is_subscribe_push(Type) of
                  true ->
-                     ct:pal("Subscribe push: ~p", [Value]),
                      handle_subscribe_push(Value, State);
                  false ->
                      State
@@ -266,11 +265,9 @@ is_subscribe_push(_) ->
 handle_subscribe_push(PushMessage, State) ->
     case try_pop_waiting(State) of
         {PoppedWaiting, State1} ->
-            ct:pal("When push came ~p, popped waiting ~p", [PushMessage, PoppedWaiting]),
             handle_subscribed_popped_waiting(PushMessage, PoppedWaiting, State1);
         none ->
             %% No commands pending.
-            ct:pal("No commands pending when push came: ~p", [PushMessage]),
             State
     end.
 

--- a/test/ered_SUITE.erl
+++ b/test/ered_SUITE.erl
@@ -399,15 +399,24 @@ t_subscribe(_) ->
     {ok, 0} = ered:command(R, [<<"publish">>, <<"ch2">>, <<"world">>], <<"x">>),
     ?MSG({push, [<<"message">>, <<"ch2">>, <<"world">>]}),
 
+    %% Psubscribe (channel counter is sum of patterns, channels and
+    %% shard-channels)
+    {ok, undefined} = ered:command(R, [<<"psubscribe">>, <<"ch*">>], <<"k">>),
+    ?MSG({push, [<<"psubscribe">>, <<"ch*">>, 5]}),
+
     %% Unsubscribe some.
     {ok, undefined} = ered:command(R, [<<"unsubscribe">>, <<"ch2">>, <<"ch1">>], <<"k">>),
-    ?MSG({push, [<<"unsubscribe">>, _Ch1, 3]}),
-    ?MSG({push, [<<"unsubscribe">>, _Ch2, 2]}),
+    ?MSG({push, [<<"unsubscribe">>, _Ch1, 4]}),
+    ?MSG({push, [<<"unsubscribe">>, _Ch2, 3]}),
 
     %% Unsubscribe all.
     {ok, undefined} = ered:command(R, [<<"unsubscribe">>], <<"k">>),
-    ?MSG({push, [<<"unsubscribe">>, _Ch3, 1]}),
-    ?MSG({push, [<<"unsubscribe">>, _Ch4, 0]}),
+    ?MSG({push, [<<"unsubscribe">>, _Ch3, 2]}),
+    ?MSG({push, [<<"unsubscribe">>, _Ch4, 1]}),
+
+    %% Punsubscribe all.
+    {ok, undefined} = ered:command(R, [<<"punsubscribe">>], <<"k">>),
+    ?MSG({push, [<<"punsubscribe">>, <<"ch*">>, 0]}),
 
     %% Sharded pubsub in Redis 7+. May return a MOVED redirect, but here it is CROSSSLOT.
     {ok, {error, Reason}} = ered:command(R, [<<"ssubscribe">>, <<"a">>, <<"b">>], <<"a">>),

--- a/test/ered_connection_tests.erl
+++ b/test/ered_connection_tests.erl
@@ -33,7 +33,7 @@ trailing_reply_test() ->
     ?debugFmt("~w", [Conn1]),
     ered_connection:command_async(Conn1, [<<"ping">>], ping1),
     receive sent_big_nasty -> ok end,
-    MalformedCommand = {redis_command, 1, undefined},
+    MalformedCommand = {redis_command, pipeline, [undefined]},
     ered_connection:command_async(Conn1, MalformedCommand, no_ref),
 
     %% make sure the ping is received before the connection is shut down


### PR DESCRIPTION
Special handling of commands "subscribe", "unsubscribe", "psubscribe", "punsubscribe", "ssubscribe", "sunsubscribe". These commands don't return anything apart from push messages, so they require special handling in the client implementation.

The commands mentioned above, when successful, don't return anything other than one push message per subscribed or unsubscribed channel. The pushed messages are passed to the push callback provided using the connection option `push_cb`. ered:command/3,4 returns `{ok, undefined}` for successful operation of these commands.

The representation of RESP-formatted pipeline commands is changed. This format is mainly used internally, but can also be passed to e.g. ered:command/3,4. The format is changed from `{redis_command, non_neg_integer(), iodata()}` to `{redis_command, pipeline, [binary()]}`.

Fixes #26