### PR TITLE
Ignore empty slotmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,11 +310,13 @@ Messages about the cluster as a whole:
     non_neg_integer()`. See options above.
 
 * `#{msg_type := slot_map_updated, slot_map := list(), map_version :=
-  non_neg_integer()}` is sent when the cluster slot-to-node mapping has been
-  updated.
+  non_neg_integer(), addr := addr()}` is sent when the cluster slot-to-node
+  mapping has been updated.
 
-* `#{msg_type := cluster_slots_error_response, response := any()}` is sent when
-  there was an error updating the cluster slot-to-node mapping.
+* `#{msg_type := cluster_slots_error_response, response := any(), addr :=
+  addr()}` is sent when there was an error updating the cluster slot-to-node
+  mapping. The `response` is either an error or the atom `empty` if the CLUSTER
+  SLOTS returned an empty list, which is treated like an error.
 
 Messages about the connection to a specific node are in the following form:
 

--- a/src/ered_cluster.erl
+++ b/src/ered_cluster.erl
@@ -219,7 +219,7 @@ handle_info(Msg = {connection_status, {_Pid, Addr, _Id} , Status}, State) ->
             {noreply, update_cluster_state(ClusterStatus, State1)}
     end;
 
-handle_info({slot_info, Version, Response}, State) ->
+handle_info({slot_info, Version, Response, FromAddr}, State) ->
     case Response of
         _ when Version < State#st.slot_map_version ->
             %% got a response for a request triggered for an old version of the slot map, ignore
@@ -229,11 +229,11 @@ handle_info({slot_info, Version, Response}, State) ->
             {noreply, State};
         {ok, {error, Error}} ->
             %% error sent from redis
-            ered_info_msg:cluster_slots_error_response(Error, State#st.info_pid),
+            ered_info_msg:cluster_slots_error_response(Error, FromAddr, State#st.info_pid),
             {noreply, State};
         {ok, []} ->
             %% Empty slotmap. Maybe the node has been CLUSTER RESET.
-            ered_info_msg:cluster_slots_error_response(empty, State#st.info_pid),
+            ered_info_msg:cluster_slots_error_response(empty, FromAddr, State#st.info_pid),
             {noreply, State};
         {ok, ClusterSlotsReply} ->
             NewMap = lists:sort(ClusterSlotsReply),
@@ -259,7 +259,8 @@ handle_info({slot_info, Version, Response}, State) ->
                     NewClosing = maps:merge(maps:from_list([{Addr, TimerRef} || Addr <- Remove]),
                                             State#st.closing),
 
-                    ered_info_msg:slot_map_updated(ClusterSlotsReply, Version + 1, State#st.info_pid),
+                    ered_info_msg:slot_map_updated(ClusterSlotsReply, Version + 1,
+                                                   FromAddr, State#st.info_pid),
 
                     %% open new clients
                     State1 = start_clients(Nodes, State),
@@ -398,9 +399,10 @@ stop_periodic_slot_info_request(State) ->
             State#st{slot_timer_ref = none}
     end.
 
-send_slot_info_request(Node, State) ->
+send_slot_info_request(Addr, State) ->
+    Node = maps:get(Addr, State#st.nodes),
     Pid = self(),
-    Cb = fun(Answer) -> Pid ! {slot_info, State#st.slot_map_version, Answer} end,
+    Cb = fun(Answer) -> Pid ! {slot_info, State#st.slot_map_version, Answer, Addr} end,
     ered_client:command_async(Node, [<<"CLUSTER">>, <<"SLOTS">>], Cb).
 
 %% Pick a random available node, preferring the ones in PreferredNodes if any of
@@ -412,15 +414,9 @@ pick_node(PreferredNodes, State) ->
     case pick_available_node(shuffle(PreferredNodes), State) of
         none ->
             %% No preferred node available. Pick one from the 'up' set.
-            Addr = pick_available_node(shuffle(sets:to_list(State#st.up)), State);
+            pick_available_node(shuffle(sets:to_list(State#st.up)), State);
         Addr ->
             Addr
-    end,
-    case Addr of
-        none ->
-            none;
-        _ ->
-            maps:get(Addr, State#st.nodes)
     end.
 
 shuffle(List) ->

--- a/src/ered_info_msg.erl
+++ b/src/ered_info_msg.erl
@@ -3,8 +3,8 @@
 %% Functions used to format and send info messages
 
 -export([connection_status/3,
-         slot_map_updated/3,
-         cluster_slots_error_response/2,
+         slot_map_updated/4,
+         cluster_slots_error_response/3,
          cluster_ok/1,
          cluster_nok/2
         ]).
@@ -44,9 +44,11 @@
 
         #{msg_type := slot_map_updated,
           slot_map := ClusterSlotsReply :: any(),
+          addr := addr(),
           map_version := non_neg_integer()} |
 
         #{msg_type := cluster_slots_error_response,
+          addr := addr(),
           response := RedisReply :: any()} |
 
         #{msg_type := cluster_ok} |
@@ -86,24 +88,26 @@ connection_status(ClientInfo, IsMaster, Pids) ->
               Pids).
 
 %% - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
--spec slot_map_updated(ered_lib:slot_map(), non_neg_integer(), [pid()]) -> ok.
+-spec slot_map_updated(ered_lib:slot_map(), non_neg_integer(), addr(), [pid()]) -> ok.
 %%
 %% A new slot map received from Redis, different from the current one.
 %% - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-slot_map_updated(ClusterSlotsReply, Version, Pids) ->
+slot_map_updated(ClusterSlotsReply, Version, FromAddr, Pids) ->
     send_info(#{msg_type => slot_map_updated,
                 slot_map => ClusterSlotsReply,
+                addr => FromAddr,
                 map_version => Version},
               Pids).
 
 
 %% - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
--spec cluster_slots_error_response(binary() | empty, [pid()]) -> ok.
+-spec cluster_slots_error_response(binary() | empty, addr(), [pid()]) -> ok.
 %%
 %% Redis returned an error message when trying to fetch the slot map.
 %% - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-cluster_slots_error_response(Response, Pids) ->
+cluster_slots_error_response(Response, FromAddr, Pids) ->
     send_info(#{msg_type => cluster_slots_error_response,
+                addr => FromAddr,
                 response => Response},
               Pids).
 

--- a/src/ered_info_msg.erl
+++ b/src/ered_info_msg.erl
@@ -98,9 +98,9 @@ slot_map_updated(ClusterSlotsReply, Version, Pids) ->
 
 
 %% - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
--spec cluster_slots_error_response(binary(), [pid()]) -> ok.
+-spec cluster_slots_error_response(binary() | empty, [pid()]) -> ok.
 %%
-%% Redis returned and error message when trying to fetch the slot map.
+%% Redis returned an error message when trying to fetch the slot map.
 %% - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 cluster_slots_error_response(Response, Pids) ->
     send_info(#{msg_type => cluster_slots_error_response,

--- a/test/ered_SUITE.erl
+++ b/test/ered_SUITE.erl
@@ -348,7 +348,7 @@ t_empty_initial_slotmap(_) ->
 
     %% Ered updates the slotmap repeatedly until all slots are covered and all
     %% masters have a replica. In the end, we're connected to all nodes.
-    [?MSG(#{msg_type := connected, addr := {"127.0.0.1", Port}})
+    [?MSG(#{msg_type := connected, addr := {"127.0.0.1", Port}}, 10000)
      || Port <- ?PORTS],
     ?MSG(#{msg_type := cluster_ok}),
 


### PR DESCRIPTION
An empty response from CLUSTER SLOTS can mean that an admin has done CLUSTER RESET on a node, for example after a failover. If an empty slotmap i accepted, ered forgets all nodes and cannot recover again. Ignoring these responses instead results in repeated tries to update the slotmap until a non-empty slotmap is returned from one of the nodes.

Additional change: Include node address in info msg about updated slotmap.