### PR TITLE
Fault tolerance

### DIFF
--- a/src/ered.erl
+++ b/src/ered.erl
@@ -35,9 +35,12 @@
 %%%===================================================================
 
 -record(st, {cluster_pid :: pid(),
-             slots :: binary(),       % The byte att offset N is an index into
-                                                % the clients tuple for slot N.
-             clients = {} :: tuple(), % ... of pid() (or addr() as placeholder)
+             slots :: binary(),                 % The byte att offset N is an
+                                                % index into the clients tuple
+                                                % for slot N.
+             clients = {} :: tuple(),           % Tuple of pid(), or addr() as
+                                                % placeholder when the process
+                                                % is gone.
              slot_map_version = 0 :: non_neg_integer(),
              addr_map = #{} :: #{addr() => pid() | Placeholder :: addr()},
              pending = #{} :: #{gen_server:from() => pid()},

--- a/src/ered.erl
+++ b/src/ered.erl
@@ -35,8 +35,9 @@
 %%%===================================================================
 
 -record(st, {cluster_pid :: pid(),
-             slots :: binary(), % byte at slot maps to index in clients tuple
-             clients = {} :: tuple(), % of pid() (or addr() as placeholder)
+             slots :: binary(),       % The byte att offset N is an index into
+                                                % the clients tuple for slot N.
+             clients = {} :: tuple(), % ... of pid() (or addr() as placeholder)
              slot_map_version = 0 :: non_neg_integer(),
              addr_map = #{} :: #{addr() => pid() | Placeholder :: addr()},
              pending = #{} :: #{gen_server:from() => pid()},

--- a/src/ered.erl
+++ b/src/ered.erl
@@ -35,7 +35,7 @@
 %%%===================================================================
 
 -record(st, {cluster_pid :: pid(),
-             slots :: binary(),                 % The byte att offset N is an
+             slots :: binary(),                 % The byte at offset N is an
                                                 % index into the clients tuple
                                                 % for slot N.
              clients = {} :: tuple(),           % Tuple of pid(), or addr() as

--- a/src/ered.erl
+++ b/src/ered.erl
@@ -35,10 +35,11 @@
 %%%===================================================================
 
 -record(st, {cluster_pid :: pid(),
-             slots :: binary(),
-             clients = {} :: tuple(), % of pid()
+             slots :: binary(), % byte at slot maps to index in clients tuple
+             clients = {} :: tuple(), % of pid() (or addr() as placeholder)
              slot_map_version = 0 :: non_neg_integer(),
-             addr_map = {},
+             addr_map = #{} :: #{addr() => pid() | Placeholder :: addr()},
+             pending = #{} :: #{gen_server:from() => pid()},
              try_again_delay :: non_neg_integer(),
              redirect_attempts :: non_neg_integer()
             }).
@@ -211,8 +212,8 @@ init([Addrs, Opts1]) ->
 
 handle_call({command, Command, Key}, From, State) ->
     Slot = ered_lib:hash(Key),
-    send_command_to_slot(Command, Slot, From, State, State#st.redirect_attempts),
-    {noreply, State};
+    State1 = send_command_to_slot(Command, Slot, From, State, State#st.redirect_attempts),
+    {noreply, State1};
 
 handle_call(get_clients, _From, State) ->
     {reply, tuple_to_list(State#st.clients), State};
@@ -222,8 +223,11 @@ handle_call(get_addr_to_client_map, _From, State) ->
 
 handle_cast({command_async, Command, Key, ReplyFun}, State) ->
     Slot = ered_lib:hash(Key),
-    send_command_to_slot(Command, Slot, ReplyFun, State, State#st.redirect_attempts),
-    {noreply, State};
+    State1 = send_command_to_slot(Command, Slot, ReplyFun, State, State#st.redirect_attempts),
+    {noreply, State1};
+
+handle_cast({replied, To}, State) ->
+    {noreply, State#st{pending = maps:remove(To, State#st.pending)}};
 
 handle_cast({update_slots, ClientRef}, State) ->
     ered_cluster:update_slots(State#st.cluster_pid, State#st.slot_map_version, ClientRef),
@@ -244,8 +248,8 @@ handle_cast({forward_command_asking, Command, Slot, From, Addr, AttemptsLeft, Ol
     {noreply, State1}.
 
 handle_info({command_try_again, Command, Slot, From, AttemptsLeft}, State) ->
-    send_command_to_slot(Command, Slot, From, State, AttemptsLeft),
-    {noreply, State};
+    State1 = send_command_to_slot(Command, Slot, From, State, AttemptsLeft),
+    {noreply, State1};
 
 handle_info(#{msg_type := slot_map_updated}, State) ->
     {MapVersion, ClusterMap, AddrToPid} = ered_cluster:get_slot_map_info(State#st.cluster_pid),
@@ -261,33 +265,62 @@ handle_info(#{msg_type := slot_map_updated}, State) ->
 
     Slots = create_lookup_table(ClusterMap, AddrToIx),
     Clients = create_client_pid_tuple(MasterAddrToPid, AddrToIx),
+    %% Monitor the client processes
+    maps:foreach(fun (Addr, Pid) when map_get(Addr, State#st.addr_map) =:= Pid ->
+                         ok; % Process already known
+                     (Addr, Pid) ->
+                         _ = monitor(process, Pid, [{tag, {'DOWN', Addr}}])
+                 end,
+                 AddrToPid),
     {noreply, State#st{slots = Slots,
                        clients = Clients,
                        slot_map_version = MapVersion,
                        addr_map = AddrToPid}};
 
-handle_info(#{msg_type := _, addr := Addr, client_id := Pid}, State)
+handle_info(#{msg_type := connected, addr := Addr, client_id := Pid},
+            State = #st{addr_map = AddrMap, clients = Clients})
   when is_map(State#st.addr_map) ->
-    case maps:find(Addr, State#st.addr_map) of
+    case maps:find(Addr, AddrMap) of
         {ok, Pid} ->
+            %% We already have this pid.
             {noreply, State};
         {ok, OldPid} ->
             %% The pid has changed for this client. It was probably restarted.
+            _Mon = monitor(process, Pid, [{tag, {'DOWN', Addr}}]),
             %% Replace the pid in our lookup tables.
             ClientList = [case P of
                               OldPid -> Pid;
                               Other -> Other
-                          end || P <- tuple_to_list(State#st.clients)],
-            State1 = State#st{addr_map = (State#st.addr_map)#{Addr := Pid},
-                              clients = list_to_tuple(ClientList)},
-            {noreply, State1};
+                          end || P <- tuple_to_list(Clients)],
+            {noreply, State#st{addr_map = AddrMap#{Addr := Pid},
+                               clients = list_to_tuple(ClientList)}};
         error ->
-            %% This address is not part of the slot mapping anymore.
-            {noreply, State}
+            _Mon = monitor(process, Pid, [{tag, {'DOWN', Addr}}]),
+            {noreply, State#st{addr_map = AddrMap#{Addr => Pid}}}
     end;
 
+handle_info({{'DOWN', Addr}, _Mon, process, Pid, ExitReason}, State)
+  when map_get(Addr, State#st.addr_map) =:= Pid ->
+    %% Client process is down. Abort all requests to this client.
+    Pending = maps:fold(fun (From, To, Acc) when To =:= Pid ->
+                                gen_server:reply(From, {error, ExitReason}),
+                                maps:remove(From, Acc);
+                            (_From, _To, Acc) ->
+                                Acc
+                        end,
+                        State#st.pending,
+                        State#st.pending),
+    %% Put a placeholder instead of a pid in the lookup structures.
+    Placeholder = Addr,
+    ClientList = [case P of
+                      Pid -> Placeholder;
+                      Other -> Other
+                  end || P <- tuple_to_list(State#st.clients)],
+    {noreply, State#st{addr_map = (State#st.addr_map)#{Addr := Placeholder},
+                       clients = list_to_tuple(ClientList),
+                       pending = Pending}};
+
 handle_info(_Ignore, State) ->
-    %% Could use a proxy process to receive the slot map udate to avoid this catch all handle_info
     {noreply, State}.
 
 terminate(_Reason, State) ->
@@ -306,16 +339,30 @@ format_status(_Opt, Status) ->
 send_command_to_slot(Command, Slot, From, State, AttemptsLeft) ->
     case binary:at(State#st.slots, Slot) of
         0 ->
-            reply(From, {error, unmapped_slot});
+            reply(From, {error, unmapped_slot}, none),
+            State;
         Ix ->
-            Client = element(Ix, State#st.clients),
-            Fun = create_reply_fun(Command, Slot, Client, From, State, AttemptsLeft),
-            ered_client:command_async(Client, Command, Fun)
-    end,
-    ok.
+            case element(Ix, State#st.clients) of
+                Client when is_pid(Client) ->
+                    Fun = create_reply_fun(Command, Slot, Client, From, State, AttemptsLeft),
+                    ered_client:command_async(Client, Command, Fun),
+                    put_pending(From, Client, State);
+                _Placeholder ->
+                    reply(From, {error, client_down}, none),
+                    State
+            end
+    end.
+
+put_pending(From = {_, _}, Client, State) ->
+    %% Gen_server call. Store so we can reply if Client crashes.
+    State#st{pending = maps:put(From, Client, State#st.pending)};
+put_pending(ReplyFun, _Client, State) when is_function(ReplyFun) ->
+    %% Cast with reply fun. We don't keep track of those.
+    State.
 
 create_reply_fun(_Command, _Slot, _Client, From, _State, 0) ->
-    fun(Reply) -> reply(From, Reply) end;
+    Pid = self(),
+    fun(Reply) -> reply(From, Reply, Pid) end;
 
 create_reply_fun(Command, Slot, Client, From, State, AttemptsLeft) ->
     Pid = self(),
@@ -327,7 +374,7 @@ create_reply_fun(Command, Slot, Client, From, State, AttemptsLeft) ->
     fun(Reply) ->
             case ered_command:check_result(Reply) of
                 normal ->
-                    reply(From, Reply);
+                    reply(From, Reply, Pid);
                 {moved, Addr} ->
                     ered_cluster:update_slots(ClusterPid, SlotMapVersion, Client),
                     gen_server:cast(Pid, {forward_command, Command, Slot, From, Addr, AttemptsLeft-1});
@@ -337,15 +384,18 @@ create_reply_fun(Command, Slot, Client, From, State, AttemptsLeft) ->
                     erlang:send_after(TryAgainDelay, Pid, {command_try_again, Command, Slot, From, AttemptsLeft-1});
                 cluster_down ->
                     ered_cluster:update_slots(ClusterPid, SlotMapVersion, Client),
-                    reply(From, Reply)
+                    reply(From, Reply, Pid)
             end
     end.
 
 %% Handle a reply, either by sending it back to a gen server caller or by
 %% applying a reply function.
-reply(To = {_, _}, Reply) ->
+reply(To = {_, _}, Reply, EredPid) when is_pid(EredPid) ->
+    gen_server:reply(To, Reply),
+    gen_server:cast(EredPid, {replied, To});
+reply(To = {_, _}, Reply, none) ->
     gen_server:reply(To, Reply);
-reply(ReplyFun, Reply) when is_function(ReplyFun, 1) ->
+reply(ReplyFun, Reply, _EredPid) when is_function(ReplyFun, 1) ->
     ReplyFun(Reply).
 
 create_client_pid_tuple(AddrToPid, AddrToIx) ->
@@ -380,6 +430,7 @@ connect_addr(Addr, State) ->
     case maps:get(Addr, State#st.addr_map, not_found) of
         not_found ->
             Client = ered_cluster:connect_node(State#st.cluster_pid, Addr),
+            _Mon = monitor(process, Client, [{tag, {'DOWN', Addr}}]),
             {Client, State#st{addr_map = maps:put(Addr, Client, State#st.addr_map)}};
         Client ->
             {Client, State}

--- a/src/ered_client_sup.erl
+++ b/src/ered_client_sup.erl
@@ -1,0 +1,30 @@
+-module(ered_client_sup).
+
+%% This is the supervisor for the ered_client processes of a custer client instance.
+
+-export([start_link/0, start_client/4, stop_client/2]).
+
+-behaviour(supervisor).
+-export([init/1]).
+
+-type host() :: inet:socket_address() | inet:hostname().
+-type addr() :: {host(), inet:port_number()}.
+
+start_link() ->
+    supervisor:start_link(?MODULE, []).
+
+-spec start_client(supervisor:sup_ref(), host(), inet:port_number(), [ered_client:opt()]) -> any().
+start_client(Sup, Host, Port, ClientOpts) ->
+    ChildSpec = #{id => {Host, Port},
+                  start => {ered_client, start_link, [Host, Port, ClientOpts]},
+                  modules => [ered_client]},
+    supervisor:start_child(Sup, ChildSpec).
+
+-spec stop_client(supervisor:sup_ref(), addr()) -> ok.
+stop_client(Sup, Addr) ->
+    ok = supervisor:terminate_child(Sup, Addr),
+    ok = supervisor:delete_child(Sup, Addr).
+
+init([]) ->
+    %% Use defaults (one_for_one; tolerate 1 restart per 5 seconds), no children yet.
+    {ok, {#{}, []}}.

--- a/src/ered_cluster.erl
+++ b/src/ered_cluster.erl
@@ -201,7 +201,7 @@ handle_info(Msg = {connection_status, {Pid, Addr, _Id}, Status}, State0) ->
                 error ->
                     %% Node not part of the cluster and was already removed.
                     State0
-             end,
+            end,
     IsMaster = sets:is_element(Addr, State#st.masters),
     ered_info_msg:connection_status(Msg, IsMaster, State#st.info_pid),
     State1 = case Status of

--- a/src/ered_cluster.erl
+++ b/src/ered_cluster.erl
@@ -29,6 +29,8 @@
 
 -record(st, {
              cluster_state = nok :: ok | nok,
+             %% Supervisor for our client processes
+             client_sup :: pid(),
              %% Mapping from address to client for all known clients
              nodes = #{} :: #{addr() => pid()},
              %% Clients in connected state
@@ -145,6 +147,7 @@ connect_node(ServerRef, Addr) ->
 %%%===================================================================
 
 init([Addrs, Opts]) ->
+    {ok, ClientSup} = ered_client_sup:start_link(),
     State = lists:foldl(
               fun ({info_pid, Val}, S)         -> S#st{info_pid = Val};
                   ({update_slot_wait, Val}, S) -> S#st{update_slot_wait = Val};
@@ -153,7 +156,7 @@ init([Addrs, Opts]) ->
                   ({close_wait, Val}, S)       -> S#st{close_wait = Val};
                   (Other, _)                   -> error({badarg, Other})
               end,
-              #st{},
+              #st{client_sup = ClientSup},
               Opts),
     {ok, start_clients(Addrs, State)}.
 
@@ -186,7 +189,19 @@ handle_cast({trigger_map_update, SlotMapVersion, Node}, State) ->
             {noreply, State}
     end.
 
-handle_info(Msg = {connection_status, {_Pid, Addr, _Id} , Status}, State) ->
+handle_info(Msg = {connection_status, {Pid, Addr, _Id}, Status}, State0) ->
+    State = case maps:find(Addr, State0#st.nodes) of
+                {ok, Pid} ->
+                    %% Client pid unchanged.
+                    State0;
+                {ok, _OldPid} ->
+                    %% New client pid for this address. It may have been
+                    %% restarted by the client supervisor.
+                    State0#st{nodes = (State0#st.nodes)#{Addr => Pid}};
+                error ->
+                    %% Node not part of the cluster and was already removed.
+                    State0
+             end,
     IsMaster = sets:is_element(Addr, State#st.masters),
     ered_info_msg:connection_status(Msg, IsMaster, State#st.info_pid),
     State1 = case Status of
@@ -303,14 +318,16 @@ handle_info({timeout, TimerRef, {close_clients, Remove}}, State) ->
                      {Addr, Tref} <- maps:to_list(maps:with(Remove, State#st.closing)),
                      Tref == TimerRef],
     Clients = maps:with(ToCloseNow, State#st.nodes),
-    [ered_client:stop(Client) || Client <- maps:values(Clients)],
+    [ered_client_sup:stop_client(State#st.client_sup, Client)
+     || Client <- maps:keys(Clients)],
     %% remove from nodes and closing map
     {noreply, State#st{nodes = maps:without(ToCloseNow, State#st.nodes),
                        up = sets:subtract(State#st.up, new_set(ToCloseNow)),
                        closing = maps:without(ToCloseNow, State#st.closing)}}.
 
 terminate(_Reason, State) ->
-    [ered_client:stop(Pid) || Pid <- maps:values(State#st.nodes)],
+    [ered_client_sup:stop_client(State#st.client_sup, Pid)
+     || Pid <- maps:keys(State#st.nodes)],
     ok.
 
 code_change(_OldVsn, State, _Extra) ->
@@ -504,7 +521,7 @@ check_replica_count(State) ->
 start_client(Addr, State) ->
     {Host, Port} = Addr,
     Opts = [{info_pid, self()}, {use_cluster_id, true}] ++ State#st.client_opts,
-    {ok, Pid} = ered_client:start_link(Host, Port, Opts),
+    {ok, Pid} = ered_client_sup:start_client(State#st.client_sup, Host, Port, Opts),
     Pid.
 
 start_clients(Addrs, State) ->

--- a/test/ered_SUITE.erl
+++ b/test/ered_SUITE.erl
@@ -1,7 +1,9 @@
 -module(ered_SUITE).
 
 -compile([export_all, nowarn_export_all]).
-
+-if(false).
+all() -> [t_client_crash].
+-else.
 all() ->
     [
      t_command,
@@ -26,7 +28,7 @@ all() ->
      t_ask_redirect,
      t_client_map
     ].
-
+-endif.
 
 -define(MSG(Pattern, Timeout),
         receive
@@ -51,11 +53,18 @@ all() ->
 init_per_suite(_Config) ->
     stop_containers(), % just in case there is junk from previous runs
     Image = os:getenv("REDIS_DOCKER_IMAGE", ?DEFAULT_REDIS_DOCKER_IMAGE),
+    EnableDebugCommand = case Image of
+                             "redis:" ++ [N, $. | _] when N >= $1, N < $7 ->
+                                 ""; % Option does not exist.
+                             _Redis7 ->
+                                 " --enable-debug-command yes"
+                         end,
     cmd_log([io_lib:format("docker run --name redis-~p -d --net=host"
                            " --restart=on-failure ~s redis-server"
+                           "~s"
                            " --cluster-enabled yes --port ~p"
                            " --cluster-node-timeout 2000;",
-                           [P, Image, P])
+                           [P, Image, EnableDebugCommand, P])
              || P <- ?PORTS]),
 
     timer:sleep(2000),
@@ -139,7 +148,7 @@ end_per_suite(_Config) ->
 stop_containers() ->
     %% Stop containers, redis-30007 used in t_new_cluster_master
     cmd_log([io_lib:format("docker stop redis-~p; docker rm redis-~p;", [P, P])
-             || P <- ?PORTS ++ [30007]]).
+             || P <- ?PORTS ++ [30007, cluster]]).
 
 
 t_command(_) ->
@@ -199,11 +208,35 @@ t_client_crash(_) ->
     Addr = {"127.0.0.1", Port},
     AddrToPid0 = ered:get_addr_to_client_map(R),
     Pid0 = maps:get(Addr, AddrToPid0),
+    monitor(process, Pid0),
+    TestPid = self(),
+    SleepCommand = [<<"DEBUG">>, <<"SLEEP">>, <<"3">>],
+    spawn_link(fun () ->
+                       Result = ered:command(R, SleepCommand, <<"k">>),
+                       TestPid ! {crashed_command_result, Result}
+               end),
+    ered:command_async(R, SleepCommand, <<"k">>,
+                       fun (Reply) ->
+                               %% We never get this reply. The process crashes
+                               %% before it is sent.
+                               TestPid ! {crashed_async_command_result, Reply}
+                       end),
     exit(Pid0, crash),
+    ?MSG({crashed_command_result, {error, crash}}),
     ?MSG(#{addr := {"127.0.0.1", Port}, master := true, msg_type := client_stopped}),
+    ?MSG({'DOWN', _Mon, process, Pid0, crash}),
     ?MSG(#{msg_type := cluster_not_ok, reason := master_down}),
-    %% Command hangs when pid is dead (FIXME)
-    %%{ok, <<"OK">>} = ered:command(R, [<<"SET">>, <<"k">>, <<"v">>], <<"k">>),
+    %% Instant error when client pid is dead. There's a race condition here. The
+    %% new client process can potentiallt come up fast and return "OK" to the
+    %% following commands.
+    {error, client_down} = ered:command(R, [<<"SET">>, <<"k">>, <<"v">>], <<"k">>),
+    ered:command_async(R, [<<"SET">>, <<"k">>, <<"v">>], <<"k">>,
+                       fun (Reply) ->
+                               %% This command does get a reply.
+                               TestPid ! {async_command_when_down, Reply}
+                       end),
+    ?MSG({async_command_when_down, {error, client_down}}),
+    %% End of race condition.
     ?MSG(#{addr := {"127.0.0.1", Port}, master := true, msg_type := connected}),
     AddrToPid1 = ered:get_addr_to_client_map(R),
     Pid1 = maps:get(Addr, AddrToPid1),

--- a/test/ered_SUITE.erl
+++ b/test/ered_SUITE.erl
@@ -290,7 +290,7 @@ t_client_killed(_) ->
     Pid1 = maps:get(Addr, AddrToPid1),
     true = (Pid1 =/= Pid0),
     {ok, <<"OK">>} = ered:command(R, [<<"SET">>, <<"k">>, <<"v">>], <<"k">>),
-    %% We don't get message 'cluster_ok' becuase we never got 'cluster_not_ok'.
+    %% We don't get message 'cluster_ok' because we never got 'cluster_not_ok'.
     no_more_msgs().
 
 


### PR DESCRIPTION
This change adds a supervisor for client processes, so a client process can crash without affecting the other client processes or the ered instance. (An ered client may crash e.g. due to a bug in OTP's TLS implementation.)

To keep track of missing or dead client processes, the ered process manages monitors to all ered_client processes, so it can properly return errors to commands handled by a crashed client process. `ered:command/3,4` returns a value in all situations. `ered:command_async/4` does not always return a value though. Specifically, if the client process crashes while handling the command, the reply callback function will never be called.

Fixes #1.