### PR TITLE
Handle dialyzer warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,5 @@ jobs:
           rebar3 eunit
       - name: Run common tests
         run: rebar3 ct
+      - name: Run dialyzer
+        run: rebar3 as test dialyzer

--- a/src/ered.erl
+++ b/src/ered.erl
@@ -61,7 +61,7 @@
 -type addr()       :: ered_cluster:addr().
 -type server_ref() :: pid().
 -type command()    :: ered_command:command().
--type reply()      :: ered_client:reply().
+-type reply()      :: ered_client:reply() | {error, unmapped_slot | client_down}.
 -type reply_fun()  :: ered_client:reply_fun().
 -type key()        :: binary().
 -type client_ref() :: ered_client:server_ref().

--- a/test/ered_SUITE.erl
+++ b/test/ered_SUITE.erl
@@ -68,7 +68,7 @@ init_per_suite(_Config) ->
     timer:sleep(2000),
     lists:foreach(fun(Port) ->
                           {ok,Pid} = ered_client:start_link("127.0.0.1", Port, []),
-                          {ok, <<"PONG">>} = ered_client:command(Pid, <<"ping">>),
+                          {ok, <<"PONG">>} = ered_client:command(Pid, [<<"ping">>]),
                           ered_client:stop(Pid)
                   end, ?PORTS),
 

--- a/test/ered_client_tests.erl
+++ b/test/ered_client_tests.erl
@@ -88,6 +88,8 @@ server_close_socket_t() ->
     expect_connection_up(Client).
 
 
+%% Suppress warning from command 'bad_request'
+-dialyzer({no_fail_call, bad_request_t/0}).
 bad_request_t() ->
     {ok, ListenSock} = gen_tcp:listen(0, [binary, {active , false}]),
     {ok, Port} = inet:port(ListenSock),
@@ -211,7 +213,8 @@ server_buffer_full_node_goes_down_t() ->
     no_more_msgs().
 
 
-
+%% Suppress warning from option 'bad_option'
+-dialyzer({no_fail_call, bad_option_t/0}).
 bad_option_t() ->
     ?_assertError({badarg,bad_option}, ered_client:start_link("127.0.0.1", 0, [bad_option])).
 

--- a/test/ered_client_tests.erl
+++ b/test/ered_client_tests.erl
@@ -34,7 +34,7 @@ request_t() ->
                        receive ok -> ok end
                end),
     Client = start_client(Port),
-    {ok, <<"pong">>} = ered_client:command(Client, <<"ping">>).
+    {ok, <<"pong">>} = ered_client:command(Client, [<<"ping">>]).
 
 
 fail_connect_t() ->
@@ -62,7 +62,7 @@ fail_parse_t() ->
     Client = start_client(Port),
     Pid = self(),
     spawn_link(fun() ->
-                       Pid ! ered_client:command(Client, <<"ping">>)
+                       Pid ! ered_client:command(Client, [<<"ping">>])
                end),
     expect_connection_up(Client),
     Reason = {recv_exit, {parse_error,{invalid_data,<<"&pong">>}}},
@@ -128,7 +128,7 @@ server_buffer_full_t() ->
     expect_connection_up(Client),
 
     Pid = self(),
-    [ered_client:command_async(Client, <<"ping">>, fun(Reply) -> Pid ! {N, Reply} end) || N <- lists:seq(1,11)],
+    [ered_client:command_async(Client, [<<"ping">>], fun(Reply) -> Pid ! {N, Reply} end) || N <- lists:seq(1,11)],
     receive {connection_status, _, queue_full} -> ok end,
     {6, {error, queue_overflow}} = get_msg(),
     receive {connection_status, _, queue_ok} -> ok end,
@@ -165,7 +165,7 @@ server_buffer_full_reconnect_t() ->
 
     Pid = self(),
     %% 5 messages will be pending, 5 messages in queue
-    [ered_client:command_async(Client, <<"ping">>, fun(Reply) -> Pid ! {N, Reply} end) || N <- lists:seq(1,11)],
+    [ered_client:command_async(Client, [<<"ping">>], fun(Reply) -> Pid ! {N, Reply} end) || N <- lists:seq(1,11)],
     receive {connection_status, _ClientInfo1, queue_full} -> ok end,
     %% 1 message over the limit, first one in queue gets kicked out
     {6, {error, queue_overflow}} = get_msg(),
@@ -196,7 +196,7 @@ server_buffer_full_node_goes_down_t() ->
     expect_connection_up(Client),
 
     Pid = self(),
-    [ered_client:command_async(Client, <<"ping">>, fun(Reply) -> Pid ! {N, Reply} end) || N <- lists:seq(1,11)],
+    [ered_client:command_async(Client, [<<"ping">>], fun(Reply) -> Pid ! {N, Reply} end) || N <- lists:seq(1,11)],
     receive {connection_status, _ClientInfo1, queue_full} -> ok end,
     {6, {error, queue_overflow}} = get_msg(),
     receive {connection_status, _ClientInfo2, {connection_down, {socket_closed, {recv_exit, closed}}}} -> ok end,
@@ -207,7 +207,7 @@ server_buffer_full_node_goes_down_t() ->
     [{N, {error, node_down}} = get_msg() || N <- [7,8,9,10,11]],
 
     %% additional commands should get a node down
-    {error, node_down} =  ered_client:command(Client, <<"ping">>),
+    {error, node_down} =  ered_client:command(Client, [<<"ping">>]),
     no_more_msgs().
 
 
@@ -236,7 +236,7 @@ send_timeout_t() ->
     Client = start_client(Port, [{connection_opts, [{response_timeout, 100}]}]),
     expect_connection_up(Client),
     Pid = self(),
-    ered_client:command_async(Client, <<"ping">>, fun(Reply) -> Pid ! {reply, Reply} end),
+    ered_client:command_async(Client, [<<"ping">>], fun(Reply) -> Pid ! {reply, Reply} end),
     %% this should come after max 1000ms
     receive {connection_status, _ClientInfo, {connection_down, {socket_closed, {recv_exit, timeout}}}} -> ok after 2000 -> timeout_error() end,
     expect_connection_up(Client),

--- a/test/ered_connection_tests.erl
+++ b/test/ered_connection_tests.erl
@@ -9,6 +9,8 @@ split_data_test() ->
     <<"OK">> = ered_connection:command(Conn1, [<<"set">>, <<"key1">>, Data]),
     Data = ered_connection:command(Conn1, [<<"get">>, <<"key1">>]).
 
+%% Supress warnings due to expected failures from MalformedCommand.
+-dialyzer({[no_fail_call, no_return], trailing_reply_test/0}).
 trailing_reply_test() ->
     Pid = self(),
     %% 277124 byte nested array, it takes a non-trivial time to parse
@@ -49,6 +51,8 @@ trailing_reply_test() ->
 receive_msg() ->
     receive Msg -> Msg end.
 
+%% This function is used from trailing_reply_test()
+-dialyzer({no_unused, ensure_empty/0}).
 ensure_empty() ->
     empty = receive Msg -> Msg after 0 -> empty end.
 


### PR DESCRIPTION
This PR handles the `dialyzer` warnings received from `rebar3`'s test profile.
Most warnings are corrected:
- Update the spec for ered:reply()
- Fix send command dialyzer warnings in tests

and a few expected warnings are suppressed, test only.

The CI will now also include a `dialyzer` run (on the test profile).