### PR TITLE
Pin versions of Github actions in CI and add dependabot for automated updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Automated dependency updates.
+#
+# For configuration options see:
+# https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   fmt:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Prepare
         run: |
           sudo apt update
@@ -35,7 +35,7 @@ jobs:
           - otp-version: 25.0.3
           - otp-version: 24.3.3
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Install Erlang/OTP
         run: |
           DEB_NAME="esl-erlang_${{ matrix.otp-version }}-1~ubuntu~focal_amd64.deb"

--- a/.github/workflows/redis-compatibility.yml
+++ b/.github/workflows/redis-compatibility.yml
@@ -13,9 +13,9 @@ jobs:
           - redis-version: 7.0.9
           - redis-version: 6.2.11
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Install redis-cli required by common tests
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@a6c3917cc929dd0345bfb2d3feaf9101823370ad # v1.4.2
         with:
           packages: redis-server
           version: 1.0


### PR DESCRIPTION
Pin the Github Action dependencies to the hash according to secure software development best practices
recommended by the Open Source Security Foundation (OpenSSF).

When developing a CI workflow, it's common to version-pin dependencies (i.e. actions/checkout@v4). However, version tags are mutable, so a malicious attacker could overwrite a version tag to point to a malicious or vulnerable commit instead.
Pinning workflow dependencies by hash ensures the dependency is immutable and its behavior is guaranteed.

This PR also adds a [dependabot](https://docs.github.com/en/code-security/dependabot) which will perform weekly checks of the Github actions used in CI.
When a newer version is found a pull request is opened to suggest a lift.

See #42
or
https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies
https://github.com/ossf/scorecard/blob/main/docs/checks.md#dependency-update-tool