### PR TITLE
Set read-only permission for Github Actions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   fmt:
     runs-on: ubuntu-20.04

--- a/.github/workflows/redis-compatibility.yml
+++ b/.github/workflows/redis-compatibility.yml
@@ -2,6 +2,9 @@ name: Redis compatibility testing
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   redis:
     name: Redis ${{ matrix.redis-version }}


### PR DESCRIPTION
This sets the default permission for CI workflows to only be able to read from the repository (scope: `contents`).

A compromised action will not be able to modify the repo or
even steal secrets since all other permission-scopes are implicit set to "none", i.e. not permitted.

More about permissions and scope can be found here:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

Part of #42 and
https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions