### PR TITLE
Setup Erlang/OTP in CI using a GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,18 @@ permissions:
 
 jobs:
   fmt:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Prepare
         run: |
           sudo apt update
           sudo apt install emacs-nox
+      - name: Install Erlang/OTP
+        uses: erlef/setup-beam@2f0cc07b4b9bea248ae098aba9e1a8a1de5ec24c # v1.17.5
+        with:
+          otp-version: '26.2.4'
+          rebar3-version: '3.23.0'
       - name: erlang-formatter
         run: |
           rebar3 as check fmt
@@ -30,20 +35,22 @@ jobs:
           fi
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        include: # See https://www.erlang-solutions.com/downloads/
-          - otp-version: 25.0.3
-          - otp-version: 24.3.3
+        include:
+          - otp-version: '27.0-rc3'
+          - otp-version: '26.2.4'
+          - otp-version: '25.3.2.11'
+          - otp-version: '24.3.4.17'
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Install Erlang/OTP
-        run: |
-          DEB_NAME="esl-erlang_${{ matrix.otp-version }}-1~ubuntu~focal_amd64.deb"
-          curl -f https://packages.erlang-solutions.com/erlang/debian/pool/$DEB_NAME -o $DEB_NAME
-          sudo dpkg --install $DEB_NAME
+        uses: erlef/setup-beam@2f0cc07b4b9bea248ae098aba9e1a8a1de5ec24c # v1.17.5
+        with:
+          otp-version: ${{ matrix.otp-version }}
+          rebar3-version: '3.23.0'
       - name: Install redis-cli
         # Required by ct
         run: |

--- a/.github/workflows/db-compatibility.yml
+++ b/.github/workflows/db-compatibility.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   valkey:
     name: Valkey ${{ matrix.valkey-version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -22,10 +22,10 @@ jobs:
           packages: redis-server
           version: 1.0
       - name: Install Erlang/OTP
-        run: |
-          DEB_NAME="esl-erlang_25.2.3-3~ubuntu~focal_amd64.deb"
-          curl -f https://packages.erlang-solutions.com/erlang/debian/pool/$DEB_NAME -o $DEB_NAME
-          sudo dpkg --install $DEB_NAME
+        uses: erlef/setup-beam@2f0cc07b4b9bea248ae098aba9e1a8a1de5ec24c # v1.17.5
+        with:
+          otp-version: '26.2.4'
+          rebar3-version: '3.23.0'
       - name: Build and run common tests
         env:
           REDIS_DOCKER_IMAGE: valkey/valkey:${{ matrix.valkey-version }}
@@ -34,7 +34,7 @@ jobs:
 
   redis:
     name: Redis ${{ matrix.redis-version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -50,10 +50,10 @@ jobs:
           packages: redis-server
           version: 1.0
       - name: Install Erlang/OTP
-        run: |
-          DEB_NAME="esl-erlang_25.2.3-3~ubuntu~focal_amd64.deb"
-          curl -f https://packages.erlang-solutions.com/erlang/debian/pool/$DEB_NAME -o $DEB_NAME
-          sudo dpkg --install $DEB_NAME
+        uses: erlef/setup-beam@2f0cc07b4b9bea248ae098aba9e1a8a1de5ec24c # v1.17.5
+        with:
+          otp-version: '26.2.4'
+          rebar3-version: '3.23.0'
       - name: Build and run common tests
         env:
           REDIS_DOCKER_IMAGE: redis:${{ matrix.redis-version }}

--- a/rebar.config
+++ b/rebar.config
@@ -9,3 +9,8 @@
 %% code formatting.
 
 {profiles, [{check, [{plugins, [{rebar3_fmt, "1.18.0"}]}]}]}.
+
+%% In OTP-26 the 'unknown function or type' warning is on by default.
+%% We disable this again due to missing supervisor types in OTP-26, see:
+%% https://github.com/erlang/otp/pull/6893
+{dialyzer, [{warnings, [no_unknown]}]}.

--- a/test/ered_client_tests.erl
+++ b/test/ered_client_tests.erl
@@ -359,9 +359,17 @@ auth_fail_t() ->
     {init_error, [<<"WRONGPASS", _/binary>>]} = expect_connection_down(Client),
     no_more_msgs().
 
+-if(?OTP_RELEASE >= 26).
+%% OTP >= 26 uses an empty hostname in the address lookup, which fails. See OTP-18543.
+-define(empty_string_host_reason, nxdomain).
+-else.
+%% OTP < 26 sees an empty hostname as a bad argument.
+-define(empty_string_host_reason, {'EXIT',badarg}).
+-endif.
+
 empty_string_host_t() ->
     {ok,Client} = ered_client:start_link("", 30000, [{info_pid, self()}]),
-    {connect_error, {'EXIT',badarg}} = expect_connection_down(Client),
+    {connect_error, ?empty_string_host_reason} = expect_connection_down(Client),
     no_more_msgs().
 
 bad_host_t() ->


### PR DESCRIPTION
This PR also adds OTP-26 and 27 to the build matrix which triggered some faults, now fixed:

- Disable warning about unknown functions or types in Dialyzer  
    [Starting with OTP-26](https://erlangforums.com/t/erlang-otp-26-0-released/2607/7) the unknown function or type warning is on by default.
    This will make Dialyzer complain about any types for which it has no definitions or can't infer.

    Gives warnings for `Unknown type supervisor:sup_ref/0` which does not seem to be an exported type.
     (but also `Unknown function ct:pal/1`, `Unknown function eunit:test/1`)



- Update test empty_string_host_t() for OTP 26  
   [ OTP-18543](https://www.erlang.org/patches/otp-26.0) which is introduced in OTP-26 states:
    "Looking up, connecting to and sending to a host with an empty name is now handled by trying to look up the address of the root domain, which fails. Previously some of these operations caused an internal exception, which contradicted type specifications."
