### PR TITLE
Use init nodes as fallback if all nodes are unavailable

### DIFF
--- a/src/ered_cluster.erl
+++ b/src/ered_cluster.erl
@@ -416,7 +416,7 @@ start_periodic_slot_info_request(PreferredNodes, State) ->
                     %% see if they are available. If they are hostnames that map
                     %% to IP addresses and all IP addresses of the cluster have
                     %% changed, then this helps us rediscover the cluster.
-                    start_clients(State#state.initial_nodes, State);
+                    start_clients(State#st.initial_nodes, State);
                 Node ->
                     send_slot_info_request(Node, State),
                     Tref = erlang:start_timer(


### PR DESCRIPTION
When attempting select a node to send a CLUSTER SLOTS to and all nodes are unavailable, connect to the init nodes. This is to be able to rediscover the cluster if all the IPs change at the same time and the init node is a hostname that is updated to point to the new IP addresses.

When one of them comes up, a `connection_status` message is sent to the cluster process, which is handled by calling `update_cluster_state` which in turn sends CLUSTER SLOTS to this node.

It's a bit hard to test this without a DNS server or a simulated node.

Fixes #56