### PR TITLE
Add convergence check, that all primaries return identical slot maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,21 @@ The following options can be passed to `start_link/2`:
   For each primary node, the min number of replicas for the cluster
   to be considered OK. Default 0.
 
+* `{convergence_check_timeout, timeout()}`
+
+  If non-zero, a check that all master nodes converge and report identical slot
+  maps, is performed before changing status from 'cluster_not_ok' to
+  'cluster_ok'. The timeout is how long to wait for replies from all the master
+  nodes. Default 1000. Set to zero to disable this check.
+
+* `{convergence_check_delay, timeout()}`
+
+  If non-zero, a check that all master nodes converge and report identical slot
+  maps, is performed even when the status is already 'cluster_ok', but only
+  after the specified delay. Default 5000. Set to zero to disable this check.
+  This option doesn't affect the convergence check when the cluster status is
+  'cluster_not_ok'.
+
 * `{close_wait, non_neg_integer()}`
 
   How long to delay the closing of clients that are no longer part of the slot

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ The following options can be passed to `start_link/2`:
   If non-zero, a check that all primary nodes converge and report identical slot
   maps, is performed before the cluster is considered OK and the 'cluster_ok'
   info message is sent. The timeout is how long to wait for replies from all the
-  master nodes. Default 1000. Set to zero to disable this check.
+  primary nodes. Default 1000. Set to zero to disable this check.
 
 * `{convergence_check_delay, timeout()}`
 

--- a/README.md
+++ b/README.md
@@ -181,18 +181,18 @@ The following options can be passed to `start_link/2`:
 
 * `{convergence_check_timeout, timeout()}`
 
-  If non-zero, a check that all master nodes converge and report identical slot
-  maps, is performed before changing status from 'cluster_not_ok' to
-  'cluster_ok'. The timeout is how long to wait for replies from all the master
-  nodes. Default 1000. Set to zero to disable this check.
+  If non-zero, a check that all primary nodes converge and report identical slot
+  maps, is performed before the cluster is considered OK and the 'cluster_ok'
+  info message is sent. The timeout is how long to wait for replies from all the
+  master nodes. Default 1000. Set to zero to disable this check.
 
 * `{convergence_check_delay, timeout()}`
 
-  If non-zero, a check that all master nodes converge and report identical slot
-  maps, is performed even when the status is already 'cluster_ok', but only
-  after the specified delay. Default 5000. Set to zero to disable this check.
-  This option doesn't affect the convergence check when the cluster status is
-  'cluster_not_ok'.
+  If non-zero, a check that all primary nodes converge and report identical slot
+  maps, is performed after a slot map update when the cluster is already
+  considered OK, but only after the specified delay. Default 5000. Set to zero
+  to disable this check. This option doesn't affect the convergence check
+  performed when the cluster is not yet considered OK.
 
 * `{close_wait, non_neg_integer()}`
 

--- a/src/ered_lib.erl
+++ b/src/ered_lib.erl
@@ -1,6 +1,6 @@
 -module(ered_lib).
 
--export([
+-export([slotmap_sort/1,
          slotmap_master_slots/1,
          slotmap_master_nodes/1,
          slotmap_all_nodes/1,
@@ -23,6 +23,17 @@
 %%%===================================================================
 %%% API
 %%%===================================================================
+
+%% - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+-spec slotmap_sort(slot_map()) -> slot_map().
+%%
+%% Sort a slotmap to be able to compare two slot maps deterministically. Sorts
+%% the shards by slot range and, within each shard, sorts the replicas by their
+%% network information (IP and port).
+%% - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+slotmap_sort(ClusterSlotsReply) ->
+    lists:sort([[Start, End, Primary | lists:sort(Replicas)]
+                || [Start, End, Primary | Replicas] <- ClusterSlotsReply]).
 
 %% - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -spec slotmap_master_slots(slot_map()) -> [{integer(), integer(), addr()}].

--- a/test/ered_SUITE.erl
+++ b/test/ered_SUITE.erl
@@ -25,6 +25,7 @@ all() ->
      t_kill_client,
      t_new_cluster_master,
      t_ask_redirect,
+     t_missing_slot,
      t_client_map
     ].
 
@@ -320,8 +321,8 @@ t_hard_failover(_) ->
     %% new slotmap when old master comes up as replica
     ?MSG(#{msg_type := slot_map_updated}, 10000),
 
-    %% a client is already connected to the node, so cluster is ok immediately
-    ?MSG(#{msg_type := cluster_ok}),
+    %% OK when cluster convergence check is done
+    ?MSG(#{msg_type := cluster_ok}, 5000),
 
     %% Ignore any previous failed reconnect attempts
     ?OPTIONAL_MSG(#{msg_type := connect_error, addr := {"127.0.0.1", Port}, reason := econnrefused}),
@@ -892,6 +893,32 @@ t_ask_redirect(_) ->
 
     %% wait a bit to let the config spread to all nodes
     timer:sleep(5000),
+    ok.
+
+%% Remove a slot. Make sure that we don't get 'cluster_ok' until the slot is
+%% covered again. Redis =< 7 has a bug that gossips back a deleted slot to the
+%% last seen owner of the slot.
+t_missing_slot(_) ->
+    R = start_cluster(),
+    Key = <<"foo">>,
+    Slot = ered_lib:hash(Key),
+    Port = get_master_from_key(R, Key),
+    Addr = {"127.0.0.1", Port},
+    AddrToPid = ered:get_addr_to_client_map(R),
+    Client = maps:get(Addr, AddrToPid),
+
+    cmd_log("redis-cli -p " ++ integer_to_list(Port) ++ " CLUSTER DELSLOTS " ++ integer_to_list(Slot)),
+    ered:update_slots(R, Client),
+    ?MSG(#{msg_type := cluster_not_ok, reason := not_all_slots_covered}),
+    timer:sleep(6000),
+    ?MSG(#{msg_type := slot_map_updated}),
+    ?OPTIONAL_MSG(#{msg_type := slot_map_updated}),
+    ?OPTIONAL_MSG(#{msg_type := slot_map_updated}),
+    no_more_msgs(),
+    cmd_log("redis-cli -p " ++ integer_to_list(Port) ++ " CLUSTER ADDSLOTS " ++ integer_to_list(Slot)),
+    ?MSG(#{msg_type := cluster_ok}, 5000),
+    ?OPTIONAL_MSG(#{msg_type := slot_map_updated}),
+    no_more_msgs(),
     ok.
 
 t_client_map(_) ->


### PR DESCRIPTION
The check is performed by sending CLUSTER SLOTS to all primaries.

Two options are added:

* `{convergence_check_timeout, timeout()}`: Time to wait for replies from the nodes. The check is performed before changing status 'cluster_not_ok' to 'cluster_ok'. Default 1000. If zero, disables the check.

* `{convergence_check_delay, timeout()}`: Time to wait before staring the check after a slot map update when the cluster status is already 'cluster_ok'. Default 5000. Set to zero to disable this extra check. Doesn't affect the above config.

Fixes #57