### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,11 @@ jobs:
         with:
           otp-version: ${{ matrix.otp-version }}
           rebar3-version: '3.23.0'
-      - name: Install redis-cli
-        # Required by ct
-        run: |
-          sudo apt update
-          sudo apt install redis-server
+      - name: Install redis-cli required by common tests
+        uses: awalsh128/cache-apt-pkgs-action@a6c3917cc929dd0345bfb2d3feaf9101823370ad # v1.4.2
+        with:
+          packages: redis-server
+          version: 1.0
       - name: Compile
         run: rebar3 compile
       - name: Run eunit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - otp-version: '27.0-rc3'
-          - otp-version: '26.2.4'
-          - otp-version: '25.3.2.11'
+          - otp-version: '27.1.1'
+          - otp-version: '26.2.5.4'
+          - otp-version: '25.3.2.15'
           - otp-version: '24.3.4.17'
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1

--- a/.github/workflows/db-compatibility.yml
+++ b/.github/workflows/db-compatibility.yml
@@ -13,6 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - valkey-version: 8.0.1
           - valkey-version: 7.2.5
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1


### PR DESCRIPTION
- Test using latest Valkey 8 in CI.
- Test with latest OTP releases in CI.
- Store installed apt packages in cache.
