### PR TITLE
Remove use of deprecated gen_server callback `format_status/2`

### DIFF
--- a/src/ered.erl
+++ b/src/ered.erl
@@ -21,7 +21,7 @@
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3, format_status/2]).
+         terminate/2, code_change/3]).
 
 -export_type([opt/0,
               command/0,
@@ -333,9 +333,6 @@ terminate(_Reason, State) ->
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
-
-format_status(_Opt, Status) ->
-    Status.
 
 %%%===================================================================
 %%% Internal functions

--- a/src/ered_client.erl
+++ b/src/ered_client.erl
@@ -16,7 +16,7 @@
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3, format_status/2]).
+         terminate/2, code_change/3]).
 
 -export_type([info_msg/0,
               addr/0,
@@ -288,9 +288,6 @@ terminate(Reason, State) ->
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
-
-format_status(_Opt, Status) ->
-    Status.
 
 %%%===================================================================
 %%% Internal functions

--- a/src/ered_cluster.erl
+++ b/src/ered_cluster.erl
@@ -17,7 +17,7 @@
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3, format_status/2]).
+         terminate/2, code_change/3]).
 
 
 -export_type([opt/0,
@@ -395,9 +395,6 @@ terminate(_Reason, State) ->
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
-
-format_status(_Opt, Status) ->
-    Status.
 
 %%%===================================================================
 %%% Internal functions


### PR DESCRIPTION
The callback `format_status(Opt, StatusData)` is deprecated from OTP 27 and give build warnings.
Removing them since they are optional and no-op's in our case.

https://www.erlang.org/doc/apps/stdlib/gen_server.html#c:format_status/2

