### PR TITLE
Add spell checker to CI

### DIFF
--- a/.github/typos.toml
+++ b/.github/typos.toml
@@ -1,0 +1,4 @@
+# See https://github.com/crate-ci/typos/blob/master/docs/reference.md to configure typos.
+
+[type.erlang.extend-identifiers]
+ba = "ba" # Used by hash/1 (CRC16)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: CI
 
-on:
-  pull_request:
-  push:
-    branches:
-      - master
+on: [push, pull_request]
 
 permissions:
   contents: read
@@ -33,6 +29,17 @@ jobs:
              echo "$status"; \
              exit 1; \
           fi
+
+  spellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Install typos
+        uses: taiki-e/install-action@278aeeb6e331c1bd610bffe45862e09452854b1a # v2.44.53
+        with:
+          tool: typos
+      - name: Run typos
+        run: typos --config=.github/typos.toml
 
   build:
     runs-on: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ least the key `msg_type`.
 
 Messages about the cluster as a whole:
 
-* `#{msg_type := cluster_ok}` is sent when the cluster is up and runnning and
+* `#{msg_type := cluster_ok}` is sent when the cluster is up and running and
   ered is connected to all nodes.
 
 * `#{msg_type := cluster_not_ok, reason := Reason}` is sent when something is

--- a/src/ered_command.erl
+++ b/src/ered_command.erl
@@ -99,7 +99,7 @@ get_response_class({redis_command, pipeline, Data}) ->
 -spec resp_class(binary()) -> response_class().
 %%
 %% Given a RESP-formatted command, returns a classification which can
-%% be used to interpret the response(s) from Redis, particularily for
+%% be used to interpret the response(s) from Redis, particularly for
 %% pubsub commands that don't return anything but expect certain push
 %% messages to indicate success.
 %%

--- a/src/ered_parser.erl
+++ b/src/ered_parser.erl
@@ -107,7 +107,7 @@ parse_initial(Token) ->
         <<"*", Rest/binary>> -> aggregate_N(parse_size(Rest), parse_array([]));
         %% RESP3
         <<"_" >>             -> {done, undefined}; % Null
-        <<",inf">>           -> {done, inf}; % float inifinity
+        <<",inf">>           -> {done, inf}; % float infinity
         <<",-inf">>          -> {done, neg_inf}; % negative infinity
         <<",nan">>           -> {done, nan}; % NaN
         <<",-nan">>          -> {done, nan}; % returned by some versions of redis

--- a/test/ered_SUITE.erl
+++ b/test/ered_SUITE.erl
@@ -416,7 +416,7 @@ t_manual_failover_then_old_master_down(_) ->
 
 t_blackhole(_) ->
     %% Simulate that a Redis node is unreachable, e.g. a network failure. We use
-    %% 'docket pause', similar to sending SIGSTOP to a process, to make one
+    %% 'docker pause', similar to sending SIGSTOP to a process, to make one
     %% Redis node unresponsive. This makes TCP recv() and connect() time out.
     CloseWait = 2000,                           % default is 10000
     NodeDownTimeout = 2000,                     % default is 2000
@@ -470,7 +470,7 @@ t_blackhole(_) ->
 
 t_blackhole_all_nodes(_) ->
     %% Simulate that all nodes are unreachable, e.g. a network failure. We use
-    %% 'docket pause', similar to sending SIGSTOP to a process, to make the
+    %% 'docker pause', similar to sending SIGSTOP to a process, to make the
     %% nodes unresponsive. This makes TCP recv() and connect() time out.
     CloseWait = 2000,                           % default is 10000
     NodeDownTimeout = 2000,                     % default is 2000
@@ -587,7 +587,7 @@ t_empty_initial_slotmap(_) ->
      || Port <- ?PORTS],
     ?MSG(#{msg_type := cluster_ok}, 5000),
 
-    %% Ingore all slotmap updates. There may be multiple of those before all
+    %% Ignore all slotmap updates. There may be multiple of those before all
     %% nodes have discovered each other. There may be incomplete slotmaps as
     %% well before all nodes have discovered each other, so the connections to
     %% some nodes may be temporarily deactivated.

--- a/test/ered_connection_tests.erl
+++ b/test/ered_connection_tests.erl
@@ -9,7 +9,7 @@ split_data_test() ->
     <<"OK">> = ered_connection:command(Conn1, [<<"set">>, <<"key1">>, Data]),
     Data = ered_connection:command(Conn1, [<<"get">>, <<"key1">>]).
 
-%% Supress warnings due to expected failures from MalformedCommand.
+%% Suppress warnings due to expected failures from MalformedCommand.
 -dialyzer({[no_fail_call, no_return], trailing_reply_test/0}).
 trailing_reply_test() ->
     Pid = self(),


### PR DESCRIPTION
Use spell checker `typos` and run CI-jobs when pushing changes.
Includes spelling corrections.
