### PR TITLE
Fix issue with reactivation of connected clients

### DIFF
--- a/src/ered_client.erl
+++ b/src/ered_client.erl
@@ -79,9 +79,10 @@
 -type addr()        :: {host(), inet:port_number()}.
 -type node_id()     :: binary() | undefined.
 -type client_info() :: {pid(), addr(), node_id()}.
--type status()      :: connection_up | {connection_down, down_reason()} | queue_ok | queue_full.
+-type status()      :: connection_up | {connection_down, down_reason()} | node_deactivated |
+                       queue_ok | queue_full.
 -type reason()      :: term(). % ssl reasons are of type any so no point being more specific
--type down_reason() :: node_down_timeout | node_deactivated |
+-type down_reason() :: node_down_timeout |
                        {client_stopped | connect_error | init_error | socket_closed,
                         reason()}.
 -type info_msg()    :: {connection_status, client_info(), status()}.
@@ -226,7 +227,7 @@ handle_cast(Command = {command, _, _}, State) ->
 
 handle_cast(deactivate, State) ->
     State1 = cancel_node_down_timer(State),
-    State2 = report_connection_status({connection_down, node_deactivated}, State1),
+    State2 = report_connection_status(node_deactivated, State1),
     State3 = reply_all({error, node_deactivated}, State2),
     {noreply, process_commands(State3#st{node_status = node_deactivated})};
 

--- a/src/ered_cluster.erl
+++ b/src/ered_cluster.erl
@@ -250,10 +250,6 @@ handle_info(Msg = {connection_status, {Pid, Addr, _Id}, Status}, State0) ->
                          false ->
                              NewState
                      end;
-                 {connection_down, node_deactivated} ->
-                     %% A deactivated node is still pending or up, but it might be
-                     %% removed later by the close_wait timer.
-                     State;
                  {connection_down,_} ->
                      State#st{up = sets:del_element(Addr, State#st.up),
                               pending = sets:del_element(Addr, State#st.pending),
@@ -262,6 +258,10 @@ handle_info(Msg = {connection_status, {Pid, Addr, _Id}, Status}, State0) ->
                      State#st{up = sets:add_element(Addr, State#st.up),
                               pending = sets:del_element(Addr, State#st.pending),
                               reconnecting = sets:del_element(Addr, State#st.reconnecting)};
+                 node_deactivated ->
+                     %% A deactivated node is still pending or up, but it might be
+                     %% removed later by the close_wait timer.
+                     State;
                  queue_full ->
                      State#st{queue_full = sets:add_element(Addr, State#st.queue_full)};
                  queue_ok ->

--- a/src/ered_info_msg.erl
+++ b/src/ered_info_msg.erl
@@ -36,6 +36,8 @@
 
         node_info(node_down_timeout, none) |
 
+        node_info(node_deactivated, none) |
+
         node_info(queue_ok, none) |
 
         node_info(queue_full, none) |
@@ -76,6 +78,7 @@ connection_status(ClientInfo, IsMaster, Pids) ->
             connection_up                        -> {connected, none};
             {connection_down, R} when is_atom(R) -> {R, none};
             {connection_down, R}                 -> R;
+            node_deactivated                     -> {node_deactivated, none};
             queue_full                           -> {queue_full, none};
             queue_ok                             -> {queue_ok, none}
         end,

--- a/test/ered_SUITE.erl
+++ b/test/ered_SUITE.erl
@@ -264,6 +264,7 @@ t_client_killed(_) ->
                        Result = ered:command(R, SleepCommand, <<"k">>),
                        TestPid ! {crashed_command_result, Result}
                end),
+    timer:sleep(200), %% Let the spawned command be sent.
     ered:command_async(R, SleepCommand, <<"k">>,
                        fun (Reply) ->
                                %% We never get this reply. The ered_client
@@ -287,7 +288,7 @@ t_client_killed(_) ->
                        end),
     ?MSG({async_command_when_down, {error, client_down}}),
     %% End of race condition.
-    ?MSG(#{addr := {"127.0.0.1", Port}, master := true, msg_type := connected}),
+    ?MSG(#{addr := {"127.0.0.1", Port}, master := true, msg_type := connected}, 10000),
     AddrToPid1 = ered:get_addr_to_client_map(R),
     Pid1 = maps:get(Addr, AddrToPid1),
     true = (Pid1 =/= Pid0),
@@ -409,7 +410,8 @@ t_manual_failover_then_old_master_down(_) ->
 
     %% We allow a number of info messages during this procedure, but not the
     %% status change events 'cluster_not_ok' and 'cluster_ok'.
-    ?OPTIONAL_MSG(#{addr := {"127.0.0.1", Port}, msg_type := connect_error}),
+    ?OPTIONAL_MSG(#{addr := {"127.0.0.1", Port}, msg_type := connect_error, reason := econnrefused}),
+    ?OPTIONAL_MSG(#{addr := {"127.0.0.1", Port}, msg_type := connect_error, reason := econnrefused}),
     ?OPTIONAL_MSG(#{addr := {"127.0.0.1", Port}, msg_type := node_down_timeout}),
     ?OPTIONAL_MSG(#{addr := {"127.0.0.1", Port}, msg_type := node_deactivated}),
     no_more_msgs().


### PR DESCRIPTION
When a cluster is starting, each node might have a different view of the slotmap.
Ered can first receive a slotmap which contains a specific node, and when
querying another node that specific node might not yet be known.
When a previously known node is missing from a received slotmap the client for
that node is deactivated, but not closed until the close_wait timeout.
If the specific node resurface in the next slotmap update then the peer is
reactivated.
    
1. Fix a problem in `handle_info({slot_info..)` that the `closing` set still contained reactivated peers.
    `NewClosing` did not contain the result of `start_clients/2`.
    
2. `node_is_available/2` could include nodes that are deactivated/closing.
    
3. Replace `{connection_down, node_deactivated}` with `node_deactivated` which don't change the state.
       When deactivating a peer ered_cluster received `{connection_down, node_deactivated}`.
       When a connected client, i.e. in `up`, was deactivated we previously removed it from
       the `up` set. If a connected peer is reactivated we don't get a `connection_up`, i.e.
       we would never add it to `up` again, we have a inconsistent state.
       If the connected peer was a master we would then never get a `cluster_ok`.
    
This fixes intermittent issues seen in `t_empty_initial_slotmap`.

Additionally:
- Fix timing issue in `t_client_killed`.
- Allow an additional connection refused message in `t_manual_failover_then_old_master_down`.
