### PR TITLE
Use `ssl:connect/4` to open TLS connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,10 +274,20 @@ Options passed to `start_link/2` as the options `{client_opts, [{connection_opts
 
   Options passed to `gen_tcp:connect/4`.
 
+* `{tcp_connect_timeout, timeout()}`
+
+  Timeout passed to `gen_tcp:connect/4`. Default infinity.
+  Deprecated. Replaced by `{connect_timeout, timeout()}`.
+
 * `{tls_options, [ssl:tls_client_option()]}`
 
   Options passed to `ssl:connect/4`. If this config parameter is present
   TLS will be used.
+
+* `{tls_connect_timeout, timeout()}`
+
+  Timeout passed to ssl:connect/4. Default infinity.
+  Deprecated. Replaced by `{connect_timeout, timeout()}`.
 
 * `{push_cb, push_cb()}`
 
@@ -289,18 +299,6 @@ Options passed to `start_link/2` as the options `{client_opts, [{connection_opts
 
   When a timeout happens, the connection is closed and the client attempts to
   set up a new connection. See the client option `node_down_timeout` above.
-
-#### Deprecated connection options
-
-* `{tcp_connect_timeout, timeout()}`
-
-  Timeout passed to `gen_tcp:connect/4`. Default infinity.
-  Replaced by `{connect_timeout, timeout()}`.
-
-* `{tls_connect_timeout, timeout()}`
-
-  Timeout passed to ssl:connect/4. Default infinity.
-  Replaced by `{connect_timeout, timeout()}`.
 
 Info messages
 -------------

--- a/README.md
+++ b/README.md
@@ -266,22 +266,18 @@ Options passed to `start_link/2` as the options `{client_opts, [{connection_opts
   If commands are queued up in the process message queue, this is the maximum
   number of messages that will be received and sent in one call. Default 16.
 
+* `{connect_timeout, timeout()}`
+
+  Timeout passed to `gen_tcp:connect/4` or `ssl:connect/4`. Default infinity.
+
 * `{tcp_options, [gen_tcp:connect_option()]}`
 
   Options passed to `gen_tcp:connect/4`.
 
-* `{tcp_connect_timeout, timeout()}`
-
-  Timeout passed to gen_tcp:connect/4. Default infinity.
-
 * `{tls_options, [ssl:tls_client_option()]}`
 
-  Options passed to `ssl:connect/3`. If this config parameter is present
+  Options passed to `ssl:connect/4`. If this config parameter is present
   TLS will be used.
-
-* `{tls_connect_timeout, timeout()}`
-
-  Timeout passed to ssl:connect/3. Default infinity.
 
 * `{push_cb, push_cb()}`
 
@@ -293,6 +289,18 @@ Options passed to `start_link/2` as the options `{client_opts, [{connection_opts
 
   When a timeout happens, the connection is closed and the client attempts to
   set up a new connection. See the client option `node_down_timeout` above.
+
+#### Deprecated connection options
+
+* `{tcp_connect_timeout, timeout()}`
+
+  Timeout passed to `gen_tcp:connect/4`. Default infinity.
+  Replaced by `{connect_timeout, timeout()}`.
+
+* `{tls_connect_timeout, timeout()}`
+
+  Timeout passed to ssl:connect/4. Default infinity.
+  Replaced by `{connect_timeout, timeout()}`.
 
 Info messages
 -------------
@@ -357,8 +365,7 @@ follows:
   `none`.
 
 * `connect_error` when connecting to the node fails or the TLS handshake fails.
-  Reason is as returned by `gen_tcp:connect/4` or `{tls_init, TlsReason}` if
-  `ssl:connect/3` fails.
+  Reason is as returned by `gen_tcp:connect/4` or `ssl:connect/4`.
 
 * `init_error` when one of the initial commands sent to Valkey has failed, such
   as the HELLO command. Reason is a list of error reasons.

--- a/src/ered_connection.erl
+++ b/src/ered_connection.erl
@@ -95,44 +95,38 @@ connect(Host, Port, Opts) ->
 %% connect_error message will be sent to the calling process.
 %% When the connection is closed a socket_closed message will be sent.
 %% to the calling process.
+%%
+%% Deprecated options:
+%%   tcp_connect_timeout - replaced by connect_timeout.
+%%   tls_connect_timeout - replaced by connect_timeout.
 %% - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 connect_async(Addr, Port, Opts) ->
     [error({badarg, BadOpt})
      || BadOpt <- proplists:get_keys(Opts) -- [batch_size, tcp_options, tls_options, push_cb, response_timeout,
-                                               tcp_connect_timeout, tls_connect_timeout]],
+                                               tcp_connect_timeout, tls_connect_timeout, connect_timeout]],
     BatchSize = proplists:get_value(batch_size, Opts, 16),
-    Timeout = proplists:get_value(response_timeout, Opts, 10000),
+    ResponseTimeout = proplists:get_value(response_timeout, Opts, 10000),
     PushCb = proplists:get_value(push_cb, Opts, fun(_) -> ok end),
     TcpOptions = proplists:get_value(tcp_options, Opts, []),
     TlsOptions = proplists:get_value(tls_options, Opts, []),
     TcpTimeout = proplists:get_value(tcp_connect_timeout, Opts, infinity),
     TlsTimeout = proplists:get_value(tls_connect_timeout, Opts, infinity),
-    Transport  = case TlsOptions of
-                     [] ->
-                         gen_tcp;
-                     _ ->
-                         ssl
-                 end,
+    {Transport, Options, Timeout0} = case TlsOptions of
+                                         [] ->
+                                             {gen_tcp, TcpOptions, TcpTimeout};
+                                         _ ->
+                                             {ssl, TlsOptions, TlsTimeout}
+                                     end,
+    Timeout = proplists:get_value(connect_timeout, Opts, Timeout0),
     Master = self(),
     spawn_link(
       fun() ->
               SendPid = self(),
-              Result = case catch gen_tcp:connect(Addr, Port, [{active, false}, binary] ++ TcpOptions, TcpTimeout) of
-                           {ok, TcpSocket} when Transport == ssl ->
-                               case ssl:connect(TcpSocket, TlsOptions, TlsTimeout) of
-                                   {ok, TlsSocket} ->
-                                       {ok, TlsSocket};
-                                   {error, TlsReason} ->
-                                       {error, {tls_init, TlsReason}}
-                               end;
-                           Else ->
-                               Else
-                       end,
-              case Result of
+              case catch Transport:connect(Addr, Port, [{active, false}, binary] ++ Options, Timeout) of
                   {ok, Socket} ->
                       Master ! {connected, SendPid},
                       Pid = spawn_link(fun() ->
-                                               ExitReason = recv_loop(Transport, Socket, PushCb, Timeout),
+                                               ExitReason = recv_loop(Transport, Socket, PushCb, ResponseTimeout),
                                                %% Inform sending process about exit
                                                SendPid ! ExitReason
                                        end),

--- a/test/ered_SUITE.erl
+++ b/test/ered_SUITE.erl
@@ -17,6 +17,7 @@ all() ->
      t_manual_failover_then_old_master_down,
      t_blackhole,
      t_blackhole_all_nodes,
+     t_connect_timeout,
      t_init_timeout,
      t_empty_slotmap,
      t_empty_initial_slotmap,
@@ -525,6 +526,19 @@ t_blackhole_all_nodes(_) ->
     [?MSG(#{msg_type := connected, addr := {"127.0.0.1", Port}}, 10000) || Port <- ?PORTS],
     ?MSG(#{msg_type := cluster_ok}, 10000),
 
+    no_more_msgs().
+
+
+t_connect_timeout(_) ->
+    %% Connect to an unreachable cluster (a blackhole address) using a configured
+    %% connect_timeout.
+    {ok, _P} = ered:start_link([{"192.168.254.254", 30001}],
+                               [{info_pid, [self()]},
+                                {client_opts,
+                                 [{connection_opts, [{connect_timeout, 100}]}]
+                                }]),
+
+    ?MSG(#{msg_type := connect_error, reason := timeout}, 200),
     no_more_msgs().
 
 


### PR DESCRIPTION
Change the TLS connect procedure to use `ssl:connect/4` directly instead
of first connecting a TCP socket and then upgrading it to TLS.

Since we previously opened a TLS connection by first connecting a TCP socket
users needed to configure both `tcp_connect_timeout` and `tls_connect_timeout`
to get a timeout when using TLS, which was a bit confusing.
Therefor this commit adds the general connection option:

- `{connect_timeout, timeout()}`

which replaces and deprecates the following options:

- `{tcp_connect_timeout, timeout()}`
- `{tls_connect_timeout, timeout()}`