### PR TITLE
Add a release CI workflow with a version check and prepare for release `0.7.1`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+# Only run this workflow on pushed tags.
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: read
+
+jobs:
+  check-version:
+    name: Check ered application version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Install Erlang/OTP
+        uses: erlef/setup-beam@5304e04ea2b355f03681464e683d92e3b2f18451 # v1.18.2
+        with:
+          otp-version: '27.1.2'
+          rebar3-version: '3.23.0'
+      - name: Check if vsn matches pushed tag (see src/ered.app.src).
+        run: |
+          rebar3 shell --apps ered --eval "$(cat << EOF
+          Version = "${{ github.ref_name }}",
+          case application:get_key(ered, vsn) of
+              {ok, Version} ->
+                  halt(0,[]);
+              Error ->
+                  io:format(user, "Version check failed, got ~p while pushed tag is ~s~n",
+                            [Error, Version]),
+                  halt(1,[]) %% Version check failed, give exitcode 1.
+          end.
+          EOF
+          )"

--- a/src/ered.app.src
+++ b/src/ered.app.src
@@ -1,6 +1,6 @@
 {application, ered,
  [{description, "Valkey Cluster client library application"},
-  {vsn, "0.6.0"},
+  {vsn, "0.7.1"},
   {registered, []},
   {applications,
    [kernel,


### PR DESCRIPTION
* Add a CI workflow that is only run when a tag is pushed to
Github, and a check that the ered application vsn is matching
the pushed tag.    
`application:get_key(ered, vsn)` is used to get the vsn version
and the shell will return an error code when the version and
the tag is not matching, which fails the CI job.

* The `0.7.0` release provided the faulty application vsn string `0.6.0`.
  Update vsn to `0.7.1` to prepare for a new release.
