### PR TITLE
Correcting issues in `ered_client` and `ered_connection`

### DIFF
--- a/src/ered_client.erl
+++ b/src/ered_client.erl
@@ -247,7 +247,7 @@ handle_info({{command_reply, Pid}, Reply}, State = #st{pending = Pending, connec
             {noreply, process_commands(State#st{pending = NewPending})}
     end;
 
-handle_info({command_reply, _Pid, _Reply}, State) ->
+handle_info({{command_reply, _Pid}, _Reply}, State) ->
     %% Stray message from a defunct client? ignore!
     {noreply, State};
 

--- a/src/ered_connection.erl
+++ b/src/ered_connection.erl
@@ -375,7 +375,7 @@ receive_data(N, Time, Acc) ->
                     Class = ered_command:get_response_class(Commands),
                     RefInfo = {Class, Pid, Ref, []},
                     Acc1 = [{RefInfo, Data} | Acc],
-                    receive_data(N, 0, Acc1)
+                    receive_data(N - 1, 0, Acc1)
             end
     after Time ->
             receive_data(0, 0, Acc)


### PR DESCRIPTION
The following issues are corrected with this PR:
- Correcting signature on function handling a `command_reply`.
    The function in `ered_client` handling stray messages from a defunct client
    has a faulty signature which could result it a crash.

- Correcting `batch_size` bug in connection options.   
    Since the batch size counter was not increased previously
    the batch size was always infinite.
   