### PR TITLE
Fix unstable tests in Github CI

### DIFF
--- a/test/ered_SUITE.erl
+++ b/test/ered_SUITE.erl
@@ -548,6 +548,7 @@ t_empty_slotmap(_) ->
            response := empty,
            addr := {"127.0.0.1", _Port}}),
     create_cluster(),
+    wait_for_consistent_cluster(),
     no_more_msgs().
 
 
@@ -563,6 +564,7 @@ t_empty_initial_slotmap(_) ->
 
     %% Now restore the cluster and check that ered reaches an OK state.
     create_cluster(),
+    wait_for_consistent_cluster(),
 
     %% Ered updates the slotmap repeatedly until all slots are covered and all
     %% masters have a replica. In the end, we're connected to all nodes.

--- a/test/ered_test_utils.erl
+++ b/test/ered_test_utils.erl
@@ -85,7 +85,7 @@ wait_for_all_nodes_available(Ports, ClientOpts) ->
 wait_for_connection_up([]) ->
     ok;
 wait_for_connection_up(Clients) ->
-    #{client_id := Client} = ?MSG(#{msg_type := connected}, 15000),
+    #{client_id := Client} = ?MSG(#{msg_type := connected}, 60000),
     {ok, <<"PONG">>} = ered_client:command(Client, [<<"ping">>]),
 
     %% Stop client and allow optional connect_error events
@@ -93,6 +93,7 @@ wait_for_connection_up(Clients) ->
     ?MSG(#{msg_type := client_stopped, client_id := Client}),
     ?OPTIONAL_MSG(#{msg_type := connect_error, client_id := Client}),
     ?OPTIONAL_MSG(#{msg_type := connect_error, client_id := Client}),
+    ?OPTIONAL_MSG(#{msg_type := node_down_timeout, client_id := Client}),
     wait_for_connection_up(lists:delete(Client, Clients)).
 
 no_more_msgs() ->


### PR DESCRIPTION
- Wait (maximum) 60 sec for containers to be running since Github runners uses `sysctl net.ipv4.tcp_fin_timeout` set to 60 sec.
Sometimes a node container would not start, and investigations showed that we got this kind of log from a valkey/redis: `Warning: Could not create server TCP listening socket *:41006: bind: Address already in use`

- Add checks for a consistent cluster to fix intermittent issues with: `t_empty_initial_slotmap`