### PR TITLE
Remove a duplicate case pattern to fix a rebase issue

### DIFF
--- a/src/ered_cluster.erl
+++ b/src/ered_cluster.erl
@@ -351,7 +351,6 @@ handle_info(Msg = #{msg_type := MsgType, client_id := _Pid, addr := Addr}, State
                              NewState
                      end;
                  _ when MsgType =:= node_down_timeout;
-                        MsgType =:= node_deactivated;
                         MsgType =:= init_error;
                         MsgType =:= client_stopped ->
                      %% Client is down.


### PR DESCRIPTION
During the rebase of PR #41 the `node_deactivated` info message got matched twice in `ered_cluster`.
This resulted in intermittent CI issues to resurface (fixed in PR #69).

A deactivated node is still pending or up, but it might be removed later by the close_wait timer.
See match on [line 365](https://github.com/Ericsson/ered/blob/cc391c3de25ea2938f1444dd5111c8e693c55943/src/ered_cluster.erl#L365) in ered_cluster.erl