### PR TITLE
Non-blocking send

### DIFF
--- a/src/ered_client.erl
+++ b/src/ered_client.erl
@@ -68,6 +68,7 @@
          waiting = q_new() :: command_queue(),
          pending = q_new() :: command_queue(),
 
+         backoff_send = false :: boolean(), % true after a send timeout
          cluster_id = undefined :: undefined | binary(),
 
          queue_full_event_sent = false :: boolean(), % set to true when full, false when reaching queue_ok_level
@@ -392,7 +393,7 @@ handle_info({Passive, Socket}, #st{socket = Socket} = State)
         {error, Reason} ->
             Transport = State#st.opts#opts.transport,
             Transport:close(Socket),
-            {noreply, connection_down({socket_closed, Reason}, State#st{socket = undefined})}
+            {noreply, connection_down({socket_closed, Reason}, State#st{socket = none})}
     end;
 
 handle_info({Error, Socket, Reason}, #st{socket = Socket} = State)
@@ -419,6 +420,7 @@ handle_info({connected, Socket}, State) ->
     State1 = abort_pending_commands(State),
     State2 = State1#st{socket = Socket,
                        connected_at = erlang:monotonic_time(millisecond),
+                       backoff_send = false,
                        status = init},
     State3 = init_connection(State2),
     {noreply, State3, response_timeout(State3)};
@@ -499,6 +501,31 @@ setopts(#st{opts = #opts{transport = gen_tcp}, socket = Socket}, Opts) ->
 setopts(#st{opts = #opts{transport = ssl}, socket = Socket}, Opts) ->
     ssl:setopts(Socket, Opts).
 
+getstat(#st{opts = #opts{transport = gen_tcp}, socket = Socket}, Opts) ->
+    inet:getstat(Socket, Opts);
+getstat(#st{opts = #opts{transport = ssl}, socket = Socket}, Opts) ->
+    ssl:getstat(Socket, Opts).
+
+update_backoff_send(State) when State#st.backoff_send ->
+    case q_len(State#st.pending) of
+        0 ->
+            %% No pending commands means nothing is waiting in the send buffer.
+            State#st{backoff_send = false};
+        1 ->
+            %% Pending queue almost empty, but maybe it was a huge command.
+            case getstat(State, [send_pend]) of
+                {ok, [{send_pend, SendPend}]} when SendPend < 1000 ->
+                    State#st{backoff_send = false};
+                _Otherwise ->
+                    State
+            end;
+        _ ->
+            %% There are still multiple pending commands. Don't send more yet.
+            State
+    end;
+update_backoff_send(State) ->
+    State.
+
 %% Data received from the server
 handle_data(Data, #st{parser_state = ParserState} = State) ->
     handle_parser_result(ered_parser:continue(Data, ParserState), State).
@@ -507,7 +534,8 @@ handle_parser_result({need_more, _BytesNeeded, ParserState}, State) ->
     State#st{parser_state = ParserState};
 handle_parser_result({done, Value, ParserState}, State0) ->
     State1 = handle_result(Value, State0),
-    handle_parser_result(ered_parser:next(ParserState), State1);
+    State2 = update_backoff_send(State1),
+    handle_parser_result(ered_parser:next(ParserState), State2);
 handle_parser_result({parse_error, Reason}, State) ->
     Transport = State#st.opts#opts.transport,
     Transport:close(State#st.socket),
@@ -654,7 +682,8 @@ process_commands(State) ->
     NumPending = q_len(State#st.pending),
     if
         State#st.status =:= up, State#st.socket =/= none,
-        NumWaiting > 0, NumPending < State#st.opts#opts.max_pending ->
+        NumWaiting > 0, NumPending < State#st.opts#opts.max_pending,
+        not State#st.backoff_send ->
             %% TODO: Pop multiple from queue and send them in a batch. Use the batch_size option.
             %% Use q_split, q_join and q_to_list.
             %% TODO: Add request timeout timestamp to PendingReq.
@@ -662,14 +691,18 @@ process_commands(State) ->
             RespCommand = Command#command.data,
             Data = ered_command:get_data(RespCommand),
             Class = ered_command:get_response_class(RespCommand),
+            PendingReq = #pending_req{command = Command,
+                                      response_class = Class},
+            StateAfterSend = State#st{pending = q_in(PendingReq, State#st.pending),
+                                      waiting = NewWaiting},
             Transport = State#st.opts#opts.transport,
             case Transport:send(State#st.socket, Data) of
                 ok ->
-                    PendingReq = #pending_req{command = Command,
-                                              response_class = Class},
-                    State1 = State#st{pending = q_in(PendingReq, State#st.pending),
-                                      waiting = NewWaiting},
-                    process_commands(State1);
+                    process_commands(StateAfterSend);
+                {error, timeout} ->
+                    %% The send succeeded, but we should back off before sending
+                    %% more. The data is queued in inet's send buffer.
+                    process_commands(StateAfterSend#st{backoff_send = true});
                 {error, _Reason} ->
                     %% Send FIN and handle replies in fligh before reconnecting.
                     Transport:shutdown(State#st.socket, read_write),
@@ -821,7 +854,7 @@ connect_loop(now, OwnerPid,
              #opts{host = Host, port = Port, transport = Transport,
                    transport_opts = TransportOpts0,
                    connect_timeout = Timeout} = Opts) ->
-    TransportOpts = [{active, 100}, binary] ++ TransportOpts0,
+    TransportOpts = [{send_timeout, 0}, {active, 100}, binary] ++ TransportOpts0,
     case Transport:connect(Host, Port, TransportOpts, Timeout) of
         {ok, Socket} ->
             case Transport:controlling_process(Socket, OwnerPid) of

--- a/src/ered_client.erl
+++ b/src/ered_client.erl
@@ -15,6 +15,9 @@
          command/2, command/3,
          command_async/3]).
 
+%% testing/debugging
+-export([state_to_map/1]).
+
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
@@ -288,6 +291,13 @@ command(ServerRef, Command, Timeout) ->
 command_async(ServerRef, Command, CallbackFun) ->
     gen_server:cast(ServerRef, #command{data = ered_command:convert_to(Command),
                                         replyto = CallbackFun}).
+
+%% Converts a state record to a map, for easier testing.
+%% Used in tests, after calling sys:get_state(EredClientPid).
+state_to_map(#st{} = State) ->
+    Fields = record_info(fields, st),
+    [st | Values] = tuple_to_list(State),
+    maps:from_list(lists:zip(Fields, Values)).
 
 %%%===================================================================
 %%% gen_server callbacks

--- a/test/ered_client_tests.erl
+++ b/test/ered_client_tests.erl
@@ -542,7 +542,7 @@ listen(ssl) ->
     CertFile = "/tmp/ered_test_cert.pem",
     KeyFile = "/tmp/ered_test_key.pem",
     os:cmd("openssl req -x509 -newkey rsa:2048 -keyout " ++ KeyFile ++
-           " -out " ++ CertFile ++ " -days 1 -nodes -subj '/CN=localhost' 2>/dev/null"),
+               " -out " ++ CertFile ++ " -days 1 -nodes -subj '/CN=localhost' 2>/dev/null"),
     {ok, LSock} = ssl:listen(0, [binary, {active, false},
                                  {certfile, CertFile}, {keyfile, KeyFile}]),
     {ok, {_, Port}} = ssl:sockname(LSock),
@@ -559,4 +559,4 @@ accept(ssl, LSock) ->
 
 vsn_ge(Vsn1, Vsn2) ->
     lists:map(fun list_to_integer/1, string:tokens(Vsn1, ".")) >=
-    lists:map(fun list_to_integer/1, string:tokens(Vsn2, ".")).
+        lists:map(fun list_to_integer/1, string:tokens(Vsn2, ".")).

--- a/test/ered_client_tests.erl
+++ b/test/ered_client_tests.erl
@@ -254,13 +254,16 @@ response_timeout_t() ->
     no_more_msgs().
 
 send_backoff_t() ->
+    %% Send a large command N times.
+    N = 10,
+
     %% Construct a large binary.
-    N = 1000 * 1000,
+    Size = 1000 * 1000,
     LargeBinary = (fun Loop(0, Acc) ->
                            Acc;
                        Loop(I, Acc) ->
                            Loop(I - 1, <<Acc/binary, "a">>)
-                   end)(N, <<>>),
+                   end)(Size, <<>>),
     LargeCommand = [<<"SET">>, <<"foo">>, LargeBinary],
     Resp = ered_command:get_data(
              ered_command:convert_to([<<"SET">>, <<"foo">>, LargeBinary])),
@@ -273,12 +276,10 @@ send_backoff_t() ->
         spawn_link(fun() ->
                            {ok, Sock} = gen_tcp:accept(ListenSock),
                            receive continue -> ok end,
-                           {ok, <<"*3\r\n$3\r\nSET\r", _/binary>>} = gen_tcp:recv(Sock, RespLen),
-                           ok = gen_tcp:send(Sock, <<"+OK\r\n">>),
-                           {ok, <<"*3\r\n$3\r\nSET\r", _/binary>>} = gen_tcp:recv(Sock, RespLen),
-                           ok = gen_tcp:send(Sock, <<"+OK\r\n">>),
-                           {ok, <<"*3\r\n$3\r\nSET\r", _/binary>>} = gen_tcp:recv(Sock, RespLen),
-                           ok = gen_tcp:send(Sock, <<"+OK\r\n">>),
+                           [begin
+                                {ok, <<"*3\r\n$3\r\nSET\r", _/binary>>} = gen_tcp:recv(Sock, RespLen),
+                                ok = gen_tcp:send(Sock, <<"+OK\r\n">>)
+                            end || _ <- lists:seq(1, N)],
                            {ok, <<"*1\r\n$4\r\nping\r\n">>} = gen_tcp:recv(Sock, 0),
                            ok = gen_tcp:send(Sock, <<"+PONG\r\n">>),
                            receive ok -> ok end
@@ -287,19 +288,18 @@ send_backoff_t() ->
     Client = start_client(Port, [{connection_opts, [{tcp_options, TcpOpts}]}]),
     expect_connection_up(Client),
     Pid = self(),
-    %% Send large command three times. In some cases, gen_tcp:send returns
-    %% {error, timeout} the second time, even if the data is really large. The
-    %% 3rd command is always kept waiting though.
-    ered_client:command_async(Client, LargeCommand, fun(Reply) -> Pid ! {reply, Reply} end),
-    ered_client:command_async(Client, LargeCommand, fun(Reply) -> Pid ! {reply, Reply} end),
-    ered_client:command_async(Client, LargeCommand, fun(Reply) -> Pid ! {reply, Reply} end),
+    %% Send the large command N times. In some cases, gen_tcp:send returns
+    %% {error, timeout} after a few times, even if the data is really large.
+    [ered_client:command_async(Client, LargeCommand, fun(Reply) -> Pid ! {reply, Reply} end)
+     || _ <- lists:seq(1, N)],
+
     #{backoff_send := BackoffSend,
       pending := {NumPending, _},
       waiting := {NumWaiting, _}} = ered_client:state_to_map(sys:get_state(Client)),
     ?assert(BackoffSend),
     ?assert(NumPending > 0),
     ?assert(NumWaiting > 0),
-    ?assertEqual(3, NumWaiting + NumPending),
+    ?assertEqual(N, NumWaiting + NumPending),
     ServerPid ! continue,
     {reply, {ok, <<"OK">>}} = get_msg(),
     {reply, {ok, <<"OK">>}} = get_msg(),

--- a/test/ered_client_tests.erl
+++ b/test/ered_client_tests.erl
@@ -15,7 +15,8 @@ run_test_() ->
      {spawn, fun bad_connection_option_t/0},
      {spawn, fun server_buffer_full_reconnect_t/0},
      {spawn, fun server_buffer_full_node_goes_down_t/0},
-     {spawn, fun send_timeout_t/0},
+     {spawn, fun response_timeout_t/0},
+     {spawn, fun send_backoff_t/0},
      {spawn, fun fail_hello_t/0},
      {spawn, fun hello_with_auth_t/0},
      {spawn, fun hello_with_auth_fail_t/0},
@@ -229,7 +230,7 @@ bad_connection_option_t() ->
                                                               [{info_pid, self()},
                                                                {connection_opts, [bad_option]}])).
 
-send_timeout_t() ->
+response_timeout_t() ->
     {ok, ListenSock} = gen_tcp:listen(0, [binary, {active , false}]),
     {ok, Port} = inet:port(ListenSock),
     spawn_link(fun() ->
@@ -250,6 +251,61 @@ send_timeout_t() ->
     receive #{msg_type := socket_closed, reason := timeout} -> ok after 2000 -> timeout_error() end,
     expect_connection_up(Client),
     {reply, {ok, <<"pong">>}} = get_msg(),
+    no_more_msgs().
+
+send_backoff_t() ->
+    %% Construct a large binary.
+    N = 1000 * 1000,
+    LargeBinary = (fun Loop(0, Acc) ->
+                           Acc;
+                       Loop(I, Acc) ->
+                           Loop(I - 1, <<Acc/binary, "a">>)
+                   end)(N, <<>>),
+    LargeCommand = [<<"SET">>, <<"foo">>, LargeBinary],
+    Resp = ered_command:get_data(
+             ered_command:convert_to([<<"SET">>, <<"foo">>, LargeBinary])),
+    RespLen = byte_size(Resp),
+
+    %% Start server
+    {ok, ListenSock} = gen_tcp:listen(0, [binary, {active, false}]),
+    {ok, Port} = inet:port(ListenSock),
+    ServerPid =
+        spawn_link(fun() ->
+                           {ok, Sock} = gen_tcp:accept(ListenSock),
+                           receive continue -> ok end,
+                           {ok, <<"*3\r\n$3\r\nSET\r", _/binary>>} = gen_tcp:recv(Sock, RespLen),
+                           ok = gen_tcp:send(Sock, <<"+OK\r\n">>),
+                           {ok, <<"*3\r\n$3\r\nSET\r", _/binary>>} = gen_tcp:recv(Sock, RespLen),
+                           ok = gen_tcp:send(Sock, <<"+OK\r\n">>),
+                           {ok, <<"*3\r\n$3\r\nSET\r", _/binary>>} = gen_tcp:recv(Sock, RespLen),
+                           ok = gen_tcp:send(Sock, <<"+OK\r\n">>),
+                           {ok, <<"*1\r\n$4\r\nping\r\n">>} = gen_tcp:recv(Sock, 0),
+                           ok = gen_tcp:send(Sock, <<"+PONG\r\n">>),
+                           receive ok -> ok end
+                   end),
+    TcpOpts = [],
+    Client = start_client(Port, [{connection_opts, [{tcp_options, TcpOpts}]}]),
+    expect_connection_up(Client),
+    Pid = self(),
+    %% Send large command three times. In some cases, gen_tcp:send returns
+    %% {error, timeout} the second time, even if the data is really large. The
+    %% 3rd command is always kept waiting though.
+    ered_client:command_async(Client, LargeCommand, fun(Reply) -> Pid ! {reply, Reply} end),
+    ered_client:command_async(Client, LargeCommand, fun(Reply) -> Pid ! {reply, Reply} end),
+    ered_client:command_async(Client, LargeCommand, fun(Reply) -> Pid ! {reply, Reply} end),
+    #{backoff_send := BackoffSend,
+      pending := {NumPending, _},
+      waiting := {NumWaiting, _}} = ered_client:state_to_map(sys:get_state(Client)),
+    ?assert(BackoffSend),
+    ?assert(NumPending > 0),
+    ?assert(NumWaiting > 0),
+    ?assertEqual(3, NumWaiting + NumPending),
+    ServerPid ! continue,
+    {reply, {ok, <<"OK">>}} = get_msg(),
+    {reply, {ok, <<"OK">>}} = get_msg(),
+    {reply, {ok, <<"OK">>}} = get_msg(),
+    ered_client:command_async(Client, [<<"ping">>], fun(Reply) -> Pid ! {reply, Reply} end),
+    {reply, {ok, <<"PONG">>}} = get_msg(),
     no_more_msgs().
 
 fail_hello_t() ->

--- a/test/ered_client_tests.erl
+++ b/test/ered_client_tests.erl
@@ -17,7 +17,8 @@ run_test_() ->
      {spawn, fun server_buffer_full_reconnect_t/0},
      {spawn, fun server_buffer_full_node_goes_down_t/0},
      {spawn, fun response_timeout_t/0},
-     {spawn, fun send_backoff_t/0},
+     {spawn, fun send_backoff_tcp_t/0},
+     {spawn, fun send_backoff_tls_t/0},
      {spawn, fun fail_hello_t/0},
      {spawn, fun hello_with_auth_t/0},
      {spawn, fun hello_with_auth_fail_t/0},
@@ -302,7 +303,22 @@ response_timeout_t() ->
     {reply, {ok, <<"pong">>}} = get_msg(),
     no_more_msgs().
 
-send_backoff_t() ->
+send_backoff_tcp_t() ->
+    send_backoff_t(gen_tcp).
+
+send_backoff_tls_t() ->
+    %% ssl with {send_timeout, 0} closes the socket on timeout in
+    %% OTP 28.0 .. 28.4 (ssl 11.2.0 .. 11.5.2). It was intentionally
+    %% broken and fixed in ssl-11.5.3 (OTP-20018).
+    %% It works in OTP 27 and earlier.
+    application:load(ssl),
+    {ok, SslVsn} = application:get_key(ssl, vsn),
+    case vsn_ge(SslVsn, "11.2.0") andalso not vsn_ge(SslVsn, "11.5.3") of
+        true -> ok; %% skip
+        false -> send_backoff_t(ssl)
+    end.
+
+send_backoff_t(Transport) ->
     %% Send a large command N times.
     N = 10,
 
@@ -315,22 +331,20 @@ send_backoff_t() ->
     RespLen = byte_size(Resp),
 
     %% Start server
-    {ok, ListenSock} = gen_tcp:listen(0, [binary, {active, false}]),
-    {ok, Port} = inet:port(ListenSock),
+    {ListenSock, Port, ConnOpts} = listen(Transport),
     ServerPid =
         spawn_link(fun() ->
-                           {ok, Sock} = gen_tcp:accept(ListenSock),
+                           Sock = accept(Transport, ListenSock),
                            receive continue -> ok end,
                            [begin
-                                {ok, <<"*3\r\n$3\r\nSET\r", _/binary>>} = gen_tcp:recv(Sock, RespLen),
-                                ok = gen_tcp:send(Sock, <<"+OK\r\n">>)
+                                {ok, <<"*3\r\n$3\r\nSET\r", _/binary>>} = Transport:recv(Sock, RespLen),
+                                ok = Transport:send(Sock, <<"+OK\r\n">>)
                             end || _ <- lists:seq(1, N)],
-                           {ok, <<"*1\r\n$4\r\nping\r\n">>} = gen_tcp:recv(Sock, 0),
-                           ok = gen_tcp:send(Sock, <<"+PONG\r\n">>),
+                           {ok, <<"*1\r\n$4\r\nping\r\n">>} = Transport:recv(Sock, 0),
+                           ok = Transport:send(Sock, <<"+PONG\r\n">>),
                            receive ok -> ok end
                    end),
-    TcpOpts = [],
-    Client = start_client(Port, [{connection_opts, [{tcp_options, TcpOpts}, {batch_size, 1}]}]),
+    Client = start_client(Port, [{connection_opts, ConnOpts ++ [{batch_size, 1}]}]),
     expect_connection_up(Client),
     Pid = self(),
     %% Send the large command N times. In some cases, gen_tcp:send returns
@@ -519,3 +533,30 @@ start_client(Port, Opt) ->
 timeout_error() ->
     error({timeout, erlang:process_info(self(), messages)}).
 
+listen(gen_tcp) ->
+    {ok, LSock} = gen_tcp:listen(0, [binary, {active, false}]),
+    {ok, Port} = inet:port(LSock),
+    {LSock, Port, [{tcp_options, []}]};
+listen(ssl) ->
+    ssl:start(),
+    CertFile = "/tmp/ered_test_cert.pem",
+    KeyFile = "/tmp/ered_test_key.pem",
+    os:cmd("openssl req -x509 -newkey rsa:2048 -keyout " ++ KeyFile ++
+           " -out " ++ CertFile ++ " -days 1 -nodes -subj '/CN=localhost' 2>/dev/null"),
+    {ok, LSock} = ssl:listen(0, [binary, {active, false},
+                                 {certfile, CertFile}, {keyfile, KeyFile}]),
+    {ok, {_, Port}} = ssl:sockname(LSock),
+    {LSock, Port, [{tls_options, [{verify, verify_none}]}]}.
+
+accept(gen_tcp, LSock) ->
+    {ok, Sock} = gen_tcp:accept(LSock),
+    Sock;
+accept(ssl, LSock) ->
+    {ok, TSock} = ssl:transport_accept(LSock),
+    {ok, Sock} = ssl:handshake(TSock),
+    Sock.
+
+
+vsn_ge(Vsn1, Vsn2) ->
+    lists:map(fun list_to_integer/1, string:tokens(Vsn1, ".")) >=
+    lists:map(fun list_to_integer/1, string:tokens(Vsn2, ".")).

--- a/test/ered_client_tests.erl
+++ b/test/ered_client_tests.erl
@@ -259,11 +259,7 @@ send_backoff_t() ->
 
     %% Construct a large binary.
     Size = 1000 * 1000,
-    LargeBinary = (fun Loop(0, Acc) ->
-                           Acc;
-                       Loop(I, Acc) ->
-                           Loop(I - 1, <<Acc/binary, "a">>)
-                   end)(Size, <<>>),
+    LargeBinary = binary:copy("a", Size),
     LargeCommand = [<<"SET">>, <<"foo">>, LargeBinary],
     Resp = ered_command:get_data(
              ered_command:convert_to([<<"SET">>, <<"foo">>, LargeBinary])),


### PR DESCRIPTION
Use send_timeout 0. If send returns timeout, it has still queued all the data for sending later. When this happens, backoff and don't send more to the socket until the pending commands have got replies from the server. This requires that gen_tcp is used with the inet backend (the default) and not the socket backend.

With TLS, this approach works in older OTP versions, but it was broken for TLS in OTP 28.0 - 28.4, but fixed again in 28.4.1 (OTP-20018).

If we need to support these OTP versions, or if we want to suppor gen_tcp with the socket backend or the socket module directly, we can implement more variants later.