### PR TITLE
Replace deprecated catch operator with try...catch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           sudo apt update
           sudo apt install emacs-nox
       - name: Install Erlang/OTP
-        uses: erlef/setup-beam@e6d7c94229049569db56a7ad5a540c051a010af9 # v1.20.4
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
           otp-version: '28.1.1'
           rebar3-version: '3.25.1'
@@ -47,12 +47,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - otp-version: '29.0-rc3'
           - otp-version: '28.1.1'
           - otp-version: '27.3.4.6'
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - name: Install Erlang/OTP
-        uses: erlef/setup-beam@e6d7c94229049569db56a7ad5a540c051a010af9 # v1.20.4
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
           otp-version: ${{ matrix.otp-version }}
           rebar3-version: '3.25.1'

--- a/.github/workflows/db-compatibility.yml
+++ b/.github/workflows/db-compatibility.yml
@@ -25,7 +25,7 @@ jobs:
           packages: redis-server
           version: 1.0
       - name: Install Erlang/OTP
-        uses: erlef/setup-beam@e6d7c94229049569db56a7ad5a540c051a010af9 # v1.20.4
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
           otp-version: '28.1.1'
           rebar3-version: '3.25.1'
@@ -53,7 +53,7 @@ jobs:
           packages: redis-server faketime
           version: 1.0
       - name: Install Erlang/OTP
-        uses: erlef/setup-beam@e6d7c94229049569db56a7ad5a540c051a010af9 # v1.20.4
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
           otp-version: '28.1.1'
           rebar3-version: '3.25.1'

--- a/src/ered_cluster.erl
+++ b/src/ered_cluster.erl
@@ -583,8 +583,10 @@ handle_info(_Ignore, State) ->
     {noreply, State}.
 
 terminate(Reason, State) ->
-    catch [ered_client_sup:stop_client(State#st.client_sup, Pid)
-           || Pid <- maps:values(State#st.nodes)],
+    try [ered_client_sup:stop_client(State#st.client_sup, Pid)
+         || Pid <- maps:values(State#st.nodes)]
+    catch _:_ -> ok
+    end,
     ered_info_msg:cluster_stopped(State#st.info_pid, Reason).
 
 code_change(_OldVsn, State = #st{}, _Extra) ->

--- a/test/ered_cluster_SUITE.erl
+++ b/test/ered_cluster_SUITE.erl
@@ -68,11 +68,11 @@ init_per_testcase(_Testcase, Config) ->
     try ered_test_utils:check_consistent_cluster(?PORTS, ?CLIENT_OPTS) of
         ok ->
             [];
-        _ -> % Cluster inconsistent but all nodes reachable.
-            ct:pal("Re-initialize the cluster"),
+        _ ->
+            ct:pal("Cluster inconsistent but all nodes reachable. Re-initialize the cluster."),
             init_per_suite(Config)
-    catch _:_ -> % One or more nodes unreachable.
-            ct:pal("Re-initialize the cluster"),
+    catch _:_ ->
+            ct:pal("One or more nodes unreachable. Re-initialize the cluster."),
             init_per_suite(Config)
     end.
 

--- a/test/ered_cluster_SUITE.erl
+++ b/test/ered_cluster_SUITE.erl
@@ -65,10 +65,13 @@ init_per_suite(_Config) ->
 
 init_per_testcase(_Testcase, Config) ->
     %% Quick check that cluster is OK; otherwise restart everything.
-    case catch ered_test_utils:check_consistent_cluster(?PORTS, ?CLIENT_OPTS) of
+    try ered_test_utils:check_consistent_cluster(?PORTS, ?CLIENT_OPTS) of
         ok ->
             [];
-        _ ->
+        _ -> % Cluster inconsistent but all nodes reachable.
+            ct:pal("Re-initialize the cluster"),
+            init_per_suite(Config)
+    catch _:_ -> % One or more nodes unreachable.
             ct:pal("Re-initialize the cluster"),
             init_per_suite(Config)
     end.

--- a/test/ered_cluster_tls_SUITE.erl
+++ b/test/ered_cluster_tls_SUITE.erl
@@ -58,11 +58,11 @@ init_per_testcase(_Testcase, Config) ->
     try ered_test_utils:check_consistent_cluster(?PORTS, ?CLIENT_OPTS) of
         ok ->
             [];
-        _ -> % Cluster inconsistent but all nodes reachable.
-            ct:pal("Re-initialize the cluster"),
+        _ ->
+            ct:pal("Cluster inconsistent but all nodes reachable. Re-initialize the cluster."),
             init_per_suite(Config)
-    catch _:_ -> % One or more nodes unreachable.
-            ct:pal("Re-initialize the cluster"),
+    catch _:_ ->
+            ct:pal("One or more nodes unreachable. Re-initialize the cluster."),
             init_per_suite(Config)
     end.
 

--- a/test/ered_cluster_tls_SUITE.erl
+++ b/test/ered_cluster_tls_SUITE.erl
@@ -55,10 +55,13 @@ init_per_testcase(_Testcase, Config) ->
     generate_client_cert(),
 
     %% Quick check that cluster is OK; otherwise restart everything.
-    case catch ered_test_utils:check_consistent_cluster(?PORTS, ?CLIENT_OPTS) of
+    try ered_test_utils:check_consistent_cluster(?PORTS, ?CLIENT_OPTS) of
         ok ->
             [];
-        _ ->
+        _ -> % Cluster inconsistent but all nodes reachable.
+            ct:pal("Re-initialize the cluster"),
+            init_per_suite(Config)
+    catch _:_ -> % One or more nodes unreachable.
             ct:pal("Re-initialize the cluster"),
             init_per_suite(Config)
     end.


### PR DESCRIPTION
The catch operator is deprecated and OTP 29 will emit compiler [warnings](https://github.com/bjosv/ered/actions/runs/23447606374/job/68215569674#step:5:14) for its use.
Replaced catch with try...catch and start building with OTP 29.0-rc2 in CI.

```
===> Compiling ered
     ┌─ src/ered_connection.erl:
     │
 127 │                case catch Transport:connect(Addr, Port, [{active, false}, binary] ++ Options, Timeout) of
     │                     ╰── Warning: 'catch ...' is deprecated; please use 'try ... catch ... end' instead.
Compile directive 'nowarn_deprecated_catch' can be used to suppress
warnings in selected modules.
```


Reference:
https://www.erlang.org/news/185#compiler-warnings
